### PR TITLE
Switch to silicon repo structure

### DIFF
--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -2220,7 +2220,7 @@ bool CompilerOpenFPGA_ql::Synthesize() {
 
   // use the device specific yosys script
   m_aurora_template_script_yosys_path = 
-      std::filesystem::path(device_type_dir_path / std::string("aurora_template_script.ys"));
+      std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("aurora_template_script.ys"));
 
   if(!FileUtils::FileExists(m_aurora_template_script_yosys_path)) {
 
@@ -4535,18 +4535,11 @@ std::string CompilerOpenFPGA_ql::InitOpenFPGAScript() {
     bool use_external_template_openfpga = false;
     std::string aurora_template_script_openfpga;
 
-    // check if we have the default aurora template script available:
-    // at 'scripts/aurora_template_script.openfpga', if so, we use that.
-    std::filesystem::path aurora_template_script_openfpga_path =
-        GetSession()->Context()->DataPath() /
-        std::filesystem::path("..") /
-        std::filesystem::path("scripts") /
-        std::filesystem::path("aurora_template_script.openfpga");
-
-    if(FileUtils::FileExists(aurora_template_script_openfpga_path)) {
+    // check if we have the device aurora template script available:
+    if(FileUtils::FileExists(m_aurora_template_script_openfpga_path)) {
         
       // get it into a ifstream
-      std::ifstream stream(aurora_template_script_openfpga_path.string());
+      std::ifstream stream(m_aurora_template_script_openfpga_path.string());
         
       if (stream.good()) {
         aurora_template_script_openfpga = 
@@ -4559,12 +4552,12 @@ std::string CompilerOpenFPGA_ql::InitOpenFPGAScript() {
 
     if(use_external_template_openfpga) {
       Message("Using External OpenFPGA Template Script: " +
-                                std::string(aurora_template_script_openfpga_path.string()));
+                                std::string(m_aurora_template_script_openfpga_path.string()));
       m_openFPGAScript = aurora_template_script_openfpga;
     }
     else {
       Message("Cannot load OpenFPGA Template Script: " +
-                                std::string(aurora_template_script_openfpga_path.string()));
+                                std::string(m_aurora_template_script_openfpga_path.string()));
       Message("Using Internal OpenFPGA Template Script.");
       m_openFPGAScript = qlOpenFPGABitstreamScript;
     }
@@ -4627,32 +4620,25 @@ std::string CompilerOpenFPGA_ql::FinishOpenFPGAScript(const std::string& script)
 
   // this is optional:
   m_OpenFpgaBitstreamSettingFile = 
-      std::filesystem::path(device_type_dir_path / std::string("bitstream_annotation.xml"));
+      std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("bitstream_annotation.xml"));
   if(!std::filesystem::exists(m_OpenFpgaBitstreamSettingFile, ec)) {
     m_OpenFpgaBitstreamSettingFile.clear();
   }
 
   // this is optional:
   m_OpenFpgaRepackConstraintsFile = 
-      std::filesystem::path(device_type_dir_path / std::string("repack_design_constraint.xml"));
+      std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("repack_design_constraint.xml"));
   if(!std::filesystem::exists(m_OpenFpgaRepackConstraintsFile, ec)) {
     m_OpenFpgaRepackConstraintsFile.clear();
   }
 
   m_OpenFpgaSimSettingFile = 
-      std::filesystem::path(device_type_dir_path / std::string("fixed_sim_openfpga.xml"));
+      std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("fixed_sim_openfpga.xml"));
 
   // fabric_key
-  std::string filename_fabric_key_xml;
-  std::string filename_fabric_key_xml_en;
-  // form the file name using the current device: family_foundry_node
-  filename_fabric_key_xml = QLDeviceManager::getInstance()->getCurrentDeviceTargetString() +
-                            std::string("_fabric_key") + std::string(".xml");
-  filename_fabric_key_xml_en = filename_fabric_key_xml + std::string(".en");
-
   // fabric_key is optional:
   m_OpenFpgaFabricKeyFile = 
-      std::filesystem::path(device_type_dir_path / std::string("fabric_key") / filename_fabric_key_xml);
+      std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("fabric_key.xml"));
   if(!std::filesystem::exists(m_OpenFpgaFabricKeyFile, ec)) {
     m_OpenFpgaFabricKeyFile.clear();
   }
@@ -4667,19 +4653,19 @@ std::string CompilerOpenFPGA_ql::FinishOpenFPGAScript(const std::string& script)
     m_OpenFpgaArchitectureFile = GenerateTempFilePath();
 
     std::filesystem::path bitstream_annotation_en_path = 
-          std::filesystem::path(device_type_dir_path / std::string("bitstream_annotation.xml.en"));
+          std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("bitstream_annotation.xml.en"));
     m_OpenFpgaBitstreamSettingFile = GenerateTempFilePath();
 
     std::filesystem::path repack_constraints_en_path = 
-          std::filesystem::path(device_type_dir_path / std::string("repack_design_constraint.xml.en"));
+          std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("repack_design_constraint.xml.en"));
     m_OpenFpgaRepackConstraintsFile = GenerateTempFilePath();
 
     std::filesystem::path fixed_sim_openfpga_en_path = 
-          std::filesystem::path(device_type_dir_path / std::string("fixed_sim_openfpga.xml.en"));
+          std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("fixed_sim_openfpga.xml.en"));
     m_OpenFpgaSimSettingFile = GenerateTempFilePath();
 
     std::filesystem::path fabric_key_xml_en_path = 
-          std::filesystem::path(device_type_dir_path / std::string("fabric_key") / filename_fabric_key_xml_en);
+          std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("fabric_key.xml.en"));
     m_OpenFpgaFabricKeyFile = GenerateTempFilePath();
 
     m_cryptdbPath = 
@@ -4942,8 +4928,7 @@ std::string CompilerOpenFPGA_ql::FinishOpenFPGAScript(const std::string& script)
   // fpga_io_map
   std::filesystem::path filepath_fpga_io_map_xml;
   // form the file name using the current device: family_foundry_node
-  filepath_fpga_io_map_xml = QLDeviceManager::getInstance()->getCurrentDeviceTargetString() +
-                             std::string("_fpga_io_map") + std::string(".xml");
+  filepath_fpga_io_map_xml = std::string("fpga_io_map") + std::string(".xml");
   // generate the fpga_io_map file in the generated 'working_directory', not in the 'design_directory'
   // so the below part of code is commented out.
   // if (!filepath_fpga_io_map_xml.is_absolute()) {
@@ -5088,6 +5073,32 @@ bool CompilerOpenFPGA_ql::GenerateBitstream() {
 
   std::string command = m_openFpgaExecutablePath.string() + " -batch -f " +
                         ProjManager()->projectName() + ".openfpga";
+
+  QLDeviceTarget device_target = QLDeviceManager::getInstance()->getCurrentDeviceTarget();
+
+  std::filesystem::path device_type_dir_path = 
+      std::filesystem::path(GetSession()->Context()->DataPath() /
+                            device_target.device_variant.family /
+                            device_target.device_variant.foundry /
+                            device_target.device_variant.node);
+  
+  std::filesystem::path device_variant_dir_path =
+      std::filesystem::path(GetSession()->Context()->DataPath() /
+                            device_target.device_variant.family /
+                            device_target.device_variant.foundry /
+                            device_target.device_variant.node /
+                            device_target.device_variant.voltage_threshold /
+                            device_target.device_variant.p_v_t_corner);
+
+  // use the device specific yosys script
+  m_aurora_template_script_openfpga_path = 
+      std::filesystem::path(device_type_dir_path / std::string("aurora") / std::string("aurora_template_script.openfpga"));
+
+  if(!FileUtils::FileExists(m_aurora_template_script_openfpga_path)) {
+
+    ErrorMessage("Cannot find device OpenFPGA Template Script: " + m_aurora_template_script_openfpga_path.string());
+    return false;
+  }
 
   std::string script = InitOpenFPGAScript();
 
@@ -5290,14 +5301,13 @@ bool CompilerOpenFPGA_ql::GeneratePinConstraints(std::string& filepath_fpga_fix_
   // optionally, it can also be placed the design_directory
   std::filesystem::path filename_fpga_io_map_xml;
   std::filesystem::path filepath_fpga_io_map_xml;
-  filename_fpga_io_map_xml = QLDeviceManager::getInstance()->getCurrentDeviceTargetString() +
-                             std::string("_fpga_io_map") + std::string(".xml");
+  filename_fpga_io_map_xml = std::string("fpga_io_map") + std::string(".xml");
 
   filepath_fpga_io_map_xml = GetSession()->Context()->DataPath() /
                              device_target.device_variant.family /
                              device_target.device_variant.foundry /
                              device_target.device_variant.node /
-                             std::string("fpga_io_map") /
+                             std::string("aurora") /
                              filename_fpga_io_map_xml;
   // if the file does not exist in the device data dir
   if (!FileUtils::FileExists(filepath_fpga_io_map_xml)) {
@@ -5579,14 +5589,13 @@ std::pair<std::filesystem::path, std::string> CompilerOpenFPGA_ql::findCurrentDe
   std::filesystem::path filename_pin_table_csv;
   std::filesystem::path filepath_pin_table_csv;
 
-  filename_pin_table_csv = QLDeviceManager::getInstance()->getCurrentDeviceTargetString() +
-                           std::string("_pin_table") + std::string(".csv");
+  filename_pin_table_csv = std::string("pin_table") + std::string(".csv");
 
   filepath_pin_table_csv = GetSession()->Context()->DataPath() /
                             device_target.device_variant.family /
                             device_target.device_variant.foundry /
                             device_target.device_variant.node /
-                            std::string("pin_table") /
+                            std::string("aurora") /
                             filename_pin_table_csv;
 
 
@@ -5666,81 +5675,6 @@ int CompilerOpenFPGA_ql::CleanTempFiles() {
   m_TempFileList.clear();
 
   return count;
-}
-
-
-std::vector<std::string> CompilerOpenFPGA_ql::ListDevices() {
-
-  std::vector<std::string> empty_list_of_devices = {};
-  std::vector<std::string> list_of_devices = {};
-
-  std::string family;
-  std::string foundry;
-  std::string node;
-
-  std::error_code ec;
-
-  // get to the device_data dir path of the installation
-  std::filesystem::path root_device_data_dir_path = 
-      GetSession()->Context()->DataPath();
-
-  // each dir in the device_data is a family
-  //    for each family, check for foundry dirs
-  //        for each foundry, check for node 
-  //            for each family-foundry-node dir, check the device_variants
-  
-  // look at the directories inside the device_data_dir_path for 'family' entries
-  for (const std::filesystem::directory_entry& dir_entry_family : 
-                    std::filesystem::directory_iterator(root_device_data_dir_path)) {
-    
-    if(dir_entry_family.is_directory()) {
-      
-      // we would see family at this level
-      family = dir_entry_family.path().filename().string();
-
-      // look at the directories inside the 'family' dir for 'foundry' entries
-      for (const std::filesystem::directory_entry& dir_entry_foundry : 
-                    std::filesystem::directory_iterator(dir_entry_family.path())) {
-
-        if(dir_entry_foundry.is_directory()) {
-      
-          // we would see foundry at this level
-          foundry = dir_entry_foundry.path().filename().string();
-
-          // look at the directories inside the 'foundry' dir for 'node' entries
-          for (const std::filesystem::directory_entry& dir_entry_node : 
-                          std::filesystem::directory_iterator(dir_entry_foundry.path())) {
-
-            if(dir_entry_node.is_directory()) {
-            
-              // we would see devices at this level
-              node = dir_entry_node.path().filename().string();
-
-              // get all the device_variants for this device:
-              std::vector<std::string> device_variants;
-
-              device_variants = list_device_variants(family,
-                                                     foundry,
-                                                     node,
-                                                     dir_entry_node.path());
-              if(device_variants.empty()) {
-                // display error, but continue with other devices.
-                Message("error in parsing variants for device\n");
-              }
-              else {
-                // add all the device_variants into the list of devices.
-                list_of_devices.insert(list_of_devices.end(),
-                                      device_variants.begin(),
-                                      device_variants.end());
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-
-  return list_of_devices;
 }
 
 
@@ -5949,9 +5883,9 @@ std::vector<std::string> CompilerOpenFPGA_ql::list_device_variants(
   // [2][c] check other required and optional XML files for the device:
   // required:
   std::filesystem::path fixed_sim_openfpga_xml = 
-      device_data_dir_path_c / "fixed_sim_openfpga.xml";
+      device_data_dir_path_c / "aurora" / "fixed_sim_openfpga.xml";
   std::filesystem::path fixed_sim_openfpga_xml_en = 
-      device_data_dir_path_c / "fixed_sim_openfpga.xml.en";
+      device_data_dir_path_c / "aurora" / "fixed_sim_openfpga.xml.en";
   if(!std::filesystem::exists(fixed_sim_openfpga_xml) &&
      !std::filesystem::exists(fixed_sim_openfpga_xml_en)) {
     ErrorMessage("fixed_sim_openfpga.xml not found in source_device_data_dir_path!!!");
@@ -5960,11 +5894,11 @@ std::vector<std::string> CompilerOpenFPGA_ql::list_device_variants(
 
   // optional: not checking these for now, if needed we can add in later.
   //std::filesystem::path bitstream_annotation_xml = 
-  //    source_device_data_dir_path_c / "bitstream_annotation.xml";
+  //    source_device_data_dir_path_c / std::string("aurora") / "bitstream_annotation.xml";
   //std::filesystem::path repack_design_constraint_xml = 
-  //    source_device_data_dir_path_c / "repack_design_constraint.xml";
+  //    source_device_data_dir_path_c / std::string("aurora") / "repack_design_constraint.xml";
   //std::filesystem::path fabric_key_xml = 
-  //    source_device_data_dir_path_c / "fabric_key.xml";
+  //    source_device_data_dir_path_c / std::string("aurora") / "fabric_key.xml";
 
   return device_variants;
 }

--- a/src/Compiler/CompilerOpenFPGA_ql.h
+++ b/src/Compiler/CompilerOpenFPGA_ql.h
@@ -133,7 +133,6 @@ class CompilerOpenFPGA_ql : public Compiler {
       std::string foundry,
       std::string node,
       std::filesystem::path device_data_dir_path);
-  std::vector<std::string> ListDevices();
   long double PowerEstimator_Dynamic();
   long double PowerEstimator_Leakage();
 
@@ -189,6 +188,7 @@ class CompilerOpenFPGA_ql : public Compiler {
   std::filesystem::path m_staExecutablePath = "sta";
   std::filesystem::path m_pinConvExecutablePath = "pin_c";
   std::filesystem::path m_aurora_template_script_yosys_path;
+  std::filesystem::path m_aurora_template_script_openfpga_path;
   /*!
    * \brief m_architectureFile
    * We required from user explicitly specify architecture file.

--- a/src/Compiler/QLDeviceManager.cpp
+++ b/src/Compiler/QLDeviceManager.cpp
@@ -1160,9 +1160,9 @@ std::vector<QLDeviceVariant> QLDeviceManager::listDeviceVariants(
   // [2][c] check other required and optional XML files for the device:
   // required:
   std::filesystem::path fixed_sim_openfpga_xml = 
-      device_data_dir_path_c / "fixed_sim_openfpga.xml";
+      device_data_dir_path_c / "aurora" / "fixed_sim_openfpga.xml";
   std::filesystem::path fixed_sim_openfpga_xml_en = 
-      device_data_dir_path_c / "fixed_sim_openfpga.xml.en";
+      device_data_dir_path_c / "aurora" / "fixed_sim_openfpga.xml.en";
   if(!std::filesystem::exists(fixed_sim_openfpga_xml) &&
      !std::filesystem::exists(fixed_sim_openfpga_xml_en)) {
     std::cout << "fixed_sim_openfpga.xml not found in source_device_data_dir_path!!!" << std::endl;
@@ -1171,11 +1171,11 @@ std::vector<QLDeviceVariant> QLDeviceManager::listDeviceVariants(
 
   // optional: not checking these for now, if needed we can add in later.
   //std::filesystem::path bitstream_annotation_xml = 
-  //    source_device_data_dir_path_c / "bitstream_annotation.xml";
+  //    source_device_data_dir_path_c / std::string("aurora") / "bitstream_annotation.xml";
   //std::filesystem::path repack_design_constraint_xml = 
-  //    source_device_data_dir_path_c / "repack_design_constraint.xml";
+  //    source_device_data_dir_path_c / std::string("aurora") / "repack_design_constraint.xml";
   //std::filesystem::path fabric_key_xml = 
-  //    source_device_data_dir_path_c / "fabric_key.xml";
+  //    source_device_data_dir_path_c / std::string("aurora") / "fabric_key.xml";
 
   return device_variants;
 }
@@ -1761,7 +1761,7 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
             // exclude fpga_io_map xml files from encryption
             // include them for copy
             if (std::regex_match(dir_entry.path().filename().string(),
-                                  std::regex(".+_fpga_io_map\\.xml",
+                                  std::regex(".*fpga_io_map\\.xml",
                                   std::regex::icase))) {
               source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
               continue;
@@ -1771,7 +1771,7 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
 
           // include pin_table csv files for copy
           if (std::regex_match(dir_entry.path().filename().string(),
-                                std::regex(".+_pin_table\\.csv",
+                                std::regex(".*pin_table\\.csv",
                                 std::regex::icase))) {
             source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
           }
@@ -1786,6 +1786,13 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
           // include yosys template script for copy (aurora_template_script.ys)
           if (std::regex_match(dir_entry.path().filename().string(),
                                 std::regex("aurora_template_script\\.ys",
+                                std::regex::icase))) {
+            source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
+          }
+
+          // include openfpga template script for copy (aurora_template_script.openfpga)
+          if (std::regex_match(dir_entry.path().filename().string(),
+                                std::regex("aurora_template_script\\.openfpga",
                                 std::regex::icase))) {
             source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
           }

--- a/src/Compiler/QLDeviceManager.cpp
+++ b/src/Compiler/QLDeviceManager.cpp
@@ -1803,6 +1803,20 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
                                 std::regex::icase))) {
             source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
           }
+
+          // include system verilog files for copy (cells_sim.sv etc.)
+        if (std::regex_match(dir_entry.path().filename().string(),
+                              std::regex(".+\\.sv",
+                              std::regex::icase))) {
+          source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
+        }
+
+        // include txt files for copy (brams.txt etc.)
+        if (std::regex_match(dir_entry.path().filename().string(),
+                              std::regex(".+\\.txt",
+                              std::regex::icase))) {
+          source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
+        }
       }
 
       if(ec) {

--- a/src/Compiler/QLDeviceManager.cpp
+++ b/src/Compiler/QLDeviceManager.cpp
@@ -1754,6 +1754,22 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
       }
 
       if(dir_entry.is_regular_file(ec)) {
+
+          // skip entries which are in specific directories in device data:
+          // skip '/extra/' or '\extra\'
+          if (std::regex_match(dir_entry.path().string(),
+                                std::regex(R"(.+[\/\\]extra[\/\\].*)",
+                                std::regex::icase))) {
+            continue;
+          }
+
+          //  to skip '/examples/' or '\examples\' ? skip in future
+          // if (std::regex_match(dir_entry.path().string(),
+          //                       std::regex(R"(.+[\/\\]examples[\/\\].*)",
+          //                       std::regex::icase))) {
+          //   continue;
+          // }
+
           // we want xml files for encryption
           if (std::regex_match(dir_entry.path().filename().string(),
                                 std::regex(".+\\.xml",
@@ -1805,18 +1821,32 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
           }
 
           // include system verilog files for copy (cells_sim.sv etc.)
-        if (std::regex_match(dir_entry.path().filename().string(),
-                              std::regex(".+\\.sv",
-                              std::regex::icase))) {
-          source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
-        }
+          if (std::regex_match(dir_entry.path().filename().string(),
+                                std::regex(".+\\.sv",
+                                std::regex::icase))) {
+            source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
+          }
 
-        // include txt files for copy (brams.txt etc.)
-        if (std::regex_match(dir_entry.path().filename().string(),
-                              std::regex(".+\\.txt",
-                              std::regex::icase))) {
-          source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
-        }
+          // include txt files for copy (brams.txt etc.)
+          if (std::regex_match(dir_entry.path().filename().string(),
+                                std::regex(".+\\.txt",
+                                std::regex::icase))) {
+            source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
+          }
+
+          // include json file for copy (config.json etc.)
+          if (std::regex_match(dir_entry.path().filename().string(),
+                                std::regex(".+\\.json",
+                                std::regex::icase))) {
+            source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
+          }
+
+          // include md5 file for copy (SOFTWARE_RELEASE.md5 etc.)
+          if (std::regex_match(dir_entry.path().filename().string(),
+                                std::regex(".+\\.md5",
+                                std::regex::icase))) {
+            source_device_data_file_list_to_copy.push_back(dir_entry.path().string());
+          }
       }
 
       if(ec) {

--- a/src/Compiler/QLSettingsManager.cpp
+++ b/src/Compiler/QLSettingsManager.cpp
@@ -842,9 +842,9 @@ void QLSettingsManager::updateJSONSettingsForDeviceTarget(QLDeviceTarget device_
   
   std::filesystem::path device_data_dir_path = root_device_data_dir_path / family_updated / foundry_updated / node_updated;
 
-  std::filesystem::path settings_json_template_filepath = device_data_dir_path / "settings_template.json";
+  std::filesystem::path settings_json_template_filepath = device_data_dir_path / "aurora" / "settings_template.json";
 
-  std::filesystem::path power_json_template_filepath = device_data_dir_path / "power_template.json";
+  std::filesystem::path power_json_template_filepath = device_data_dir_path / "aurora" / "power_template.json";
 
   if(newProjectMode) {
 

--- a/src/Main/CommandLine.cpp
+++ b/src/Main/CommandLine.cpp
@@ -91,6 +91,8 @@ void CommandLine::processArgs() {
       m_version = true;
     } else if (token == "--mute") {
       m_mute = true;
+    } else if (token == "--noyosyscopy") {
+      m_noyosyscopy = true;
     } else {
       std::cout << "ERROR Unknown command line option: " << m_argv[i]
                 << std::endl;

--- a/src/Main/CommandLine.h
+++ b/src/Main/CommandLine.h
@@ -67,6 +67,7 @@ class CommandLine {
   void ErrorAndExit(const std::string& message);
   bool FileExists(const std::filesystem::path& name);
   bool Mute() const { return m_mute; }
+  bool NoYosysCopy() const { return m_noyosyscopy; }
 
  protected:
   int m_argc = 0;
@@ -83,6 +84,7 @@ class CommandLine {
   bool m_version = false;
   bool m_useVerific = false;
   bool m_mute = false;
+  bool m_noyosyscopy = false;
 };
 
 }  // namespace FOEDAG


### PR DESCRIPTION
> ### Summarize The PR

- support device data as per silicon repo structure completely
- keep support for multiple device layouts within single device (tsmc) to avoid changing entire testsuite architecture
- add support for `--noyosyscopy` flag to suppress the default 'copy /share/yosys/ files from device data to installation according to device target' behavior to facilitate parallel multiple instances of aurora to run (needed for fast CI)

> #### Describe the changes in the PR
