### PR TITLE
892 overwriting files doesnt work on mingw

### DIFF
--- a/src/Compiler/QLDeviceManager.cpp
+++ b/src/Compiler/QLDeviceManager.cpp
@@ -2079,10 +2079,9 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
         std::filesystem::remove(target_en_file_path);
       }
       std::cout << "copying:" << relative_en_file_path << std::endl;
-      std::filesystem::copy_file(source_en_file_path,
-                                 target_en_file_path,
-                                 std::filesystem::copy_options::overwrite_existing,
-                                 ec);
+      FileUtils::overwriteFile(source_en_file_path,
+                               target_en_file_path,
+                               ec);
       if(ec) {
         // error
         compiler->ErrorMessage(std::string("failed to copy: ") + source_en_file_path.string());
@@ -2123,10 +2122,9 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
       std::filesystem::remove(target_cryptdb_path);
     }
     std::cout << "copying:" << relative_cryptdb_path << std::endl;
-    std::filesystem::copy_file(source_cryptdb_path,
-                               target_cryptdb_path,
-                               std::filesystem::copy_options::overwrite_existing,
-                               ec);
+    FileUtils::overwriteFile(source_cryptdb_path,
+                             target_cryptdb_path,
+                             ec);
     if(ec) {
       // error
       compiler->ErrorMessage(std::string("failed to copy: ") + source_cryptdb_path.string());
@@ -2175,10 +2173,9 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
         std::filesystem::remove(target_file_path);
       }
       std::cout << "copying:" << relative_file_path << std::endl;
-      std::filesystem::copy_file(source_file_path,
-                                 target_file_path,
-                                 std::filesystem::copy_options::overwrite_existing,
-                                 ec);
+      FileUtils::overwriteFile(source_file_path,
+                               target_file_path,
+                               ec);
       if(ec) {
         // error
         compiler->ErrorMessage(std::string("failed to copy: ") + source_file_path.string());

--- a/src/Compiler/QLSettingsManager.cpp
+++ b/src/Compiler/QLSettingsManager.cpp
@@ -1019,20 +1019,18 @@ void QLSettingsManager::updateJSONSettingsForDeviceTarget(QLDeviceTarget device_
 
     std::error_code ec;
 
-    std::filesystem::copy_file(settings_json_template_filepath,
-                               settings_json_filepath,
-                               std::filesystem::copy_options::overwrite_existing,
-                               ec);
+    FileUtils::overwriteFile(settings_json_template_filepath,
+                             settings_json_filepath,
+                             ec);
     if(ec) {
       // error
       std::cout << std::string("failed to copy: ") + settings_json_template_filepath.string() << std::endl;
       return;
     }
 
-    std::filesystem::copy_file(power_json_template_filepath,
-                               power_estimation_json_filepath,
-                               std::filesystem::copy_options::overwrite_existing,
-                               ec);
+    FileUtils::overwriteFile(power_json_template_filepath,
+                             power_estimation_json_filepath,
+                             ec);
     if(ec) {
       // error
       std::cout << std::string("failed to copy: ") + power_json_template_filepath.string() << std::endl;

--- a/src/NewProject/ProjectManager/project_manager.cpp
+++ b/src/NewProject/ProjectManager/project_manager.cpp
@@ -330,10 +330,9 @@ int ProjectManager::CreateProject(const QString& strName,
           if(FileUtils::FileExists(source_settings_json_path)) {
             std::filesystem::path target_settings_json_path = std::filesystem::path(strPath.toStdString()) / (strName.toStdString() + ".json");
 
-            std::filesystem::copy_file(source_settings_json_path,
-                                      target_settings_json_path,
-                                      std::filesystem::copy_options::overwrite_existing,
-                                      ec);
+            FileUtils::overwriteFile(source_settings_json_path,
+                                     target_settings_json_path,
+                                     ec);
             if(ec) {
               // copy failed is a fatal error
               std::cout << "failed to copy settings json: " + source_settings_json_path.string() << " to: " << target_settings_json_path.string() << std::endl;
@@ -350,10 +349,9 @@ int ProjectManager::CreateProject(const QString& strName,
           if(FileUtils::FileExists(source_power_estimation_json_path)) {
             std::filesystem::path target_power_estimation_json_path = std::filesystem::path(strPath.toStdString()) / (strName.toStdString() + "_power" + ".json");
             std::error_code ec;
-            std::filesystem::copy_file(source_power_estimation_json_path,
-                                      target_power_estimation_json_path,
-                                      std::filesystem::copy_options::overwrite_existing,
-                                      ec);
+            FileUtils::overwriteFile(source_power_estimation_json_path,
+                                     target_power_estimation_json_path,
+                                     ec);
             if(ec) {
               // fatal error
               std::cout << "failed to copy: " + source_power_estimation_json_path.string() << " to: " << target_power_estimation_json_path.string() << std::endl;

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -333,7 +333,7 @@ void FileUtils::overwriteFile(const std::filesystem::path &source, const std::fi
     }
   }
 #endif
-  std::filesystem::copy(source, destination, std::filesystem::copy_options::overwrite_existing, ec)
+  std::filesystem::copy(source, destination, std::filesystem::copy_options::overwrite_existing, ec);
 }
 
 }  // namespace FOEDAG

--- a/src/Utils/FileUtils.cpp
+++ b/src/Utils/FileUtils.cpp
@@ -312,10 +312,28 @@ bool FileUtils::removeFile(const std::filesystem::path& file) noexcept {
 
 void FileUtils::overwriteFile(const std::filesystem::path &source, const std::filesystem::path &destination) {
   try {
+#ifdef __MINGW32__ // https://sourceforge.net/p/mingw-w64/mailman/message/37691759/
+      if (FileExists(source)) { // let's remove dest file only if source exists, to avoid situation of lost existed dest file when source doesn't exists (which fail to copy)
+        if (FileExists(destination)) {
+          removeFile(destination);
+        }
+      }
+#endif
       std::filesystem::copy(source, destination, std::filesystem::copy_options::overwrite_existing);
   } catch (const std::filesystem::filesystem_error& e) {
       std::cerr << "Error copying file: " << e.what() << std::endl;
   }
+}
+
+void FileUtils::overwriteFile(const std::filesystem::path &source, const std::filesystem::path &destination, std::error_code &ec) {
+#ifdef __MINGW32__ // https://sourceforge.net/p/mingw-w64/mailman/message/37691759/
+  if (FileExists(source)) { // let's remove dest file only if source exists, to avoid situation of lost existed dest file when source doesn't exists (which fail to copy)
+    if (FileExists(destination)) {
+      removeFile(destination);
+    }
+  }
+#endif
+  std::filesystem::copy(source, destination, std::filesystem::copy_options::overwrite_existing, ec)
 }
 
 }  // namespace FOEDAG

--- a/src/Utils/FileUtils.h
+++ b/src/Utils/FileUtils.h
@@ -81,6 +81,7 @@ class FileUtils final {
   // for the debug purposes, this function prints arguments
   static void printArgs(int argc, const char* argv[]);
   static void overwriteFile(const std::filesystem::path &source, const std::filesystem::path &destination);
+  static void overwriteFile(const std::filesystem::path &source, const std::filesystem::path &destination, std::error_code &ec);
 
  private:
   FileUtils() = delete;


### PR DESCRIPTION
- FileUtils API to enable usage of `overwrite file` scenario, without depending on the `std::filesystem::copy_options::overwrite_existing` flag which is buggy on MINGW : https://sourceforge.net/p/mingw-w64/mailman/message/37691759/
- Move all usages of `overwrite file` scenario to use the new FileUtils API instead.