### PR TITLE
1093-regression-vpr-ipa-drawing-path-contour-feature-is-broken

### DIFF
--- a/src/IpConfigurator/IpConfigWidget.cpp
+++ b/src/IpConfigurator/IpConfigWidget.cpp
@@ -199,7 +199,7 @@ void IpConfigWidget::Generate(const QString& outputPath) {
             : outputPath;
 
 #ifdef _WIN32
-    outFileStr = QString::fromStdString(FileUtils::resolvePathStr(outLocationStr.toStdString()));
+    outLocationStr = QString::fromStdString(FileUtils::resolvePathStr(outLocationStr.toStdString()));
 #endif
 
     // Build up a cmd string to generate the IP


### PR DESCRIPTION
This PR doesn't contains specific fix for the 1093-regression-vpr-ipa-drawing-path-contour-feature-is-broken
But it fixed other regression happens on windows OS after one of previous PR, which contains some renaming.