### PR TITLE
Update the command line to read the pcf file if available

### DIFF
--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -5385,6 +5385,11 @@ bool CompilerOpenFPGA_ql::GenerateIOFloorPlanConstraints() {
                         leftStr + rightStr + topStr + bottomStr + " " + 
                         output_path); 
 
+  std::filesystem::path pin_constraint_filepath = QLSettingsManager::getInstance()->getPCFFilePath();
+  if (fs::exists(floor_planning_constraint_filepath)) {
+    command += std::string(" --pcf_file ") + pin_constraint_filepath.string();
+  }
+
   int status = ExecuteAndMonitorSystemCommand(command);
 
   if (status) {


### PR DESCRIPTION
This PR updated the generate io floorplanning command generator to pass the PCF file to the floorplanning script to fix the following issue:

[Issue 1163](https://github.com/QL-Proprietary/aurora2/issues/1163)