### PR TITLE
Ignore empty lines in `qdc` file

### DIFF
--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -5335,6 +5335,11 @@ bool CompilerOpenFPGA_ql::GenerateIOFloorPlanConstraints() {
     std::string token, signalName;
     iss >> token;
 
+    if (token.empty()){
+      Message("Empty line found in QDC file. Skipping...\n");
+      continue; // Skip empty lines
+    }
+    
     if (token != "set_io_side"){
       ErrorMessage("Invalid QDC command. Expected 'set_io_side' command.");
       return false;


### PR DESCRIPTION
> ### Summarize The PR
This PR fixes the issue [#1195](https://github.com/QL-Proprietary/aurora2/issues/1195). It just a simple fix to ignore the empty lines in qdc file.

