### PR TITLE
Add initial support for analytical_place flow

### DIFF
--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -317,6 +317,7 @@ class Compiler {
   std::filesystem::path m_autoLayoutGeneratedVPRXMLPath{};
   std::filesystem::path m_autoLayoutGeneratedRRGraphBinPath{};
   std::filesystem::path m_autoLayoutGeneratedRouterLookaheadBinPath{};
+  bool m_useAnalyticalPlace = false;
 
   // Tasks generic options
   IPGenerateOpt m_ipGenerateOpt = IPGenerateOpt::None;

--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -3127,6 +3127,7 @@ std::string CompilerOpenFPGA_ql::BaseStaScript(std::string libFileName,
 }
 
 bool CompilerOpenFPGA_ql::Packing() {
+
   // Using a Scope Guard so this will fire even if we exit mid function
   // This will fire when the containing function goes out of scope
   auto guard = sg::make_scope_guard([this] {
@@ -3196,6 +3197,29 @@ bool CompilerOpenFPGA_ql::Packing() {
   }
   ofssdc.close();
 #endif // #if UPSTREAM_UNUSED
+
+
+  // reload QLSettingsManager() to ensure we account for dynamic changes in the settings/power json:
+  QLSettingsManager::reloadJSONSettings();
+
+  // check if settings were loaded correctly before proceeding:
+  if((QLSettingsManager::getInstance()->settings_json).empty()) {
+    ErrorMessage("Project Settings JSON is missing, please check <project_name> and corresponding <project_name>.json exists: " + ProjManager()->projectName());
+    return false;
+  }
+
+  if( QLSettingsManager::getStringValue("general", "options", "analytical_place") == "checked") {
+    m_useAnalyticalPlace = true;
+  }
+  else {
+    m_useAnalyticalPlace = false;
+  }
+
+  if(m_useAnalyticalPlace) {
+    m_state = State::Packed;
+    Message("Design " + ProjManager()->projectName() + " packing is skipped as we are in Analytical Place flow!");
+    return true;
+  }
 
   std::filesystem::path io_floor_planningpath = std::filesystem::path(ProjManager()->projectPath()) / 
                 std::string(ProjManager()->projectName() + "_constraints.xml");
@@ -3973,6 +3997,22 @@ bool CompilerOpenFPGA_ql::Placement() {
   }
 #endif // #if UPSTREAM_UNUSED
 
+  // reload QLSettingsManager() to ensure we account for dynamic changes in the settings/power json:
+  QLSettingsManager::reloadJSONSettings();
+
+  // check if settings were loaded correctly before proceeding:
+  if((QLSettingsManager::getInstance()->settings_json).empty()) {
+    ErrorMessage("Project Settings JSON is missing, please check <project_name> and corresponding <project_name>.json exists: " + ProjManager()->projectName());
+    return false;
+  }
+
+  if( QLSettingsManager::getStringValue("general", "options", "analytical_place") == "checked") {
+    m_useAnalyticalPlace = true;
+  }
+  else {
+    m_useAnalyticalPlace = false;
+  }
+
   // generate pin contraints file or use pre-generated .place file, if required.
   // this string should contain the path of the PinConstraints file, if generated correctly.
   // the "filepath_fpga_fix_pins_place_str" variable will be empty if:
@@ -3997,8 +4037,14 @@ bool CompilerOpenFPGA_ql::Placement() {
     command += std::string(" ") + vpr_custom_options_string;
   }
 
-  command += std::string(" ") + 
-             std::string("--place");
+  if(m_useAnalyticalPlace) {
+    command += std::string(" ") + 
+              std::string("--analytical_place");
+  }
+  else {
+    command += std::string(" ") + 
+              std::string("--place");
+  }
 
   if (!filepath_fpga_fix_pins_place_str.empty()) {
     command += std::string(" --fix_clusters") + 

--- a/src/Compiler/QLDeviceManager.cpp
+++ b/src/Compiler/QLDeviceManager.cpp
@@ -1072,25 +1072,25 @@ void QLDeviceManager::parseDeviceData() {
 
 
   // DEBUG
-  std::cout << "============ DEBUG++ ============" << std::endl;
-  for (QLDeviceType device: device_list) {
-      std::cout << "Device: " + device.family + " " + device.foundry + " " + device.node + " " + device.devicename << std::endl;
-      for (QLDeviceVariant variant: device.device_variants) {
-        std::cout << "  Variant: " +  variant.voltage_threshold + " " + variant.p_v_t_corner << std::endl;
-        for (QLDeviceVariantLayout layout: variant.device_variant_layouts) {
-          std::cout <<  "    layout_name:" + layout.name + "\n" +
-                        "              w:" + std::to_string(layout.width) + "\n" +
-                        "              h:" + std::to_string(layout.height) + "\n" +
-                        "            clb:" + std::to_string(layout.clb) + "\n" +
-                        "             io:" + std::to_string(layout.io) + "\n" +
-                        "           bram:" + std::to_string(layout.bram) + "\n" +
-                        "            dsp:" + std::to_string(layout.dsp)
-                        << std::endl;
-        }
-      }
-      std::cout << "\n" << std::endl;
-  }
-  std::cout << "============ DEBUG-- ============" << std::endl;
+  // std::cout << "============ DEBUG++ ============" << std::endl;
+  // for (QLDeviceType device: device_list) {
+  //     std::cout << "Device: " + device.family + " " + device.foundry + " " + device.node + " " + device.devicename << std::endl;
+  //     for (QLDeviceVariant variant: device.device_variants) {
+  //       std::cout << "  Variant: " +  variant.voltage_threshold + " " + variant.p_v_t_corner << std::endl;
+  //       for (QLDeviceVariantLayout layout: variant.device_variant_layouts) {
+  //         std::cout <<  "    layout_name:" + layout.name + "\n" +
+  //                       "              w:" + std::to_string(layout.width) + "\n" +
+  //                       "              h:" + std::to_string(layout.height) + "\n" +
+  //                       "            clb:" + std::to_string(layout.clb) + "\n" +
+  //                       "             io:" + std::to_string(layout.io) + "\n" +
+  //                       "           bram:" + std::to_string(layout.bram) + "\n" +
+  //                       "            dsp:" + std::to_string(layout.dsp)
+  //                       << std::endl;
+  //       }
+  //     }
+  //     std::cout << "\n" << std::endl;
+  // }
+  // std::cout << "============ DEBUG-- ============" << std::endl;
   //DEBUG
 }
 


### PR DESCRIPTION
As part of supporting new feature with updated OpenFPGA, add initial support for analytic_place flow, which can be enabled via the settings JSON, similar to `verific` enable/disable with a checkbox.

Part of Aurora PR: https://github.com/QL-Proprietary/aurora2/pull/1310