### PR TITLE
Reading maxfan From Json file

### DIFF
--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -8383,6 +8383,14 @@ std::unordered_map<int, CommandWrapperPtr> CompilerOpenFPGA_ql::getSynthesisComm
        synplifyScript->apply("${READ_SDC_FILE}", std::string("# [skipped] read sdc as the synplify mode is area."));
     }
 
+    std::string synplify_maxfan = QLSettingsManager::getInstance()->getStringValue("synplify", "general", "max_fan");
+    if (synplify_maxfan == "") {
+      synplifyScript->apply("${MAXFAN_OPTION}", "");
+    }
+    else {
+      synplifyScript->apply("${MAXFAN_OPTION}", "set_option -maxfan " + synplify_maxfan);
+    }
+
     std::string synplify_script_path = ProjManager()->projectName() + ".prj";
     synplify_script_path =
       (std::filesystem::path(ProjManager()->projectPath()) / synplify_script_path)


### PR DESCRIPTION
> ### Summarize The PR
This PR adds support for reading the maxfan parameter from the JSON configuration file and replaces the corresponding variable in the Synplify template script.
> #### Describe the changes in the PR
