### PR TITLE
Passing fpga_io_map.xml File to generate_floorplanning.py

### DIFF
--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -6572,6 +6572,13 @@ bool CompilerOpenFPGA_ql::GenerateIOFloorPlanConstraints(bool forceOverwrite) {
   if (pinTableFile.empty()) 
       Message(std::string(__func__) + ": pin table csv not found, cannot pass it to the generate_floorplanning.");
 
+  std::filesystem::path filepath_fpga_io_map_xml;
+  filepath_fpga_io_map_xml = QLDeviceManager::getInstance()->deviceOpenFPGAIOMapFile();
+  if(filepath_fpga_io_map_xml.empty()) {
+    ErrorMessage(std::string(__func__) + ": fpga io map xml not found, cannot pass it to the generate_floorplanning.");
+    return false;
+  }
+
   std::filesystem::path floor_planning_constraint_filepath = QLSettingsManager::getInstance()->getQDCFilePath();
   if (!fs::exists(floor_planning_constraint_filepath) && !fs::exists(pinTableFile)){
     Message("qdc Constraint File and Pin Table File Does Not Exist. Skipping the generate_floorplanning Script.\n");
@@ -6719,6 +6726,10 @@ bool CompilerOpenFPGA_ql::GenerateIOFloorPlanConstraints(bool forceOverwrite) {
     args.push_back("--pin_table_file");
     args.push_back(pinTableFile.string());
   }                      
+  if(fs::exists(filepath_fpga_io_map_xml)){
+    args.push_back("--fpga_io_map_xml");
+    args.push_back(filepath_fpga_io_map_xml.string());
+  }
   if(region_groups_str != "") {
     args.push_back("--region_groups");
     args.push_back(region_groups_str);


### PR DESCRIPTION
> ### Summarize The PR
This PR passes fpga_io_map.xml to generate_floorplanning.py in order to match the pin table values with fpga_io_map.xml.
> #### Describe the changes in the PR