### PR TITLE
Fix IP Catalog Python detection on macOS

### DIFF
--- a/src/Compiler/CMakeLists.txt
+++ b/src/Compiler/CMakeLists.txt
@@ -142,6 +142,7 @@ if(POWER_CALCULATOR_XLSX AND EXISTS "${POWER_CALCULATOR_XLSX}")
     "<RCC>\n  <qresource prefix=\"/\">\n    <file alias=\"build/power_calculator/power_calculator.xlsx\">${POWER_CALCULATOR_XLSX}</file>\n  </qresource>\n</RCC>\n"
   )
   list(APPEND res_LIST "${CMAKE_CURRENT_BINARY_DIR}/compiler_power_calc_resources.qrc")
+  set(HAS_POWER_CALC_RESOURCE TRUE)
 endif()
 
 add_library(compiler STATIC
@@ -152,6 +153,9 @@ add_library(compiler STATIC
 
 target_link_libraries(compiler PUBLIC Qt5::Widgets Qt5::Core Qt5::Gui Qt5::Xml cryptor)
 target_compile_definitions(compiler PRIVATE COMPILER_LIBRARY)
+if(HAS_POWER_CALC_RESOURCE)
+  target_compile_definitions(compiler PUBLIC HAS_POWER_CALC_RESOURCE)
+endif()
 
 install (
   FILES ${CMAKE_CURRENT_BINARY_DIR}/../../lib/$<TARGET_FILE_NAME:compiler>

--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -5274,6 +5274,9 @@ bool CompilerOpenFPGA_ql::PowerAnalysis() {
 #endif // _WIN32
 
   // unpack embedded in qrc xlsx file to a temprorary location
+#ifdef HAS_POWER_CALC_RESOURCE
+  Q_INIT_RESOURCE(compiler_power_calc_resources);
+#endif
   QFile qrc_xlsx_filepath(":/build/power_calculator/power_calculator.xlsx");
   if (!qrc_xlsx_filepath.open(QIODevice::ReadOnly)) {
     ErrorMessage("Cannot open power calculator data file");

--- a/src/IPGenerate/IPCatalog.cpp
+++ b/src/IPGenerate/IPCatalog.cpp
@@ -30,6 +30,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <chrono>
 #include <ctime>
 #include <filesystem>
+#include <fstream>
 #include <sstream>
 #include <thread>
 
@@ -120,7 +121,31 @@ std::filesystem::path IPCatalog::getPythonPath(const std::filesystem::path& envs
     std::filesystem::path searchPath = envsPath / "litex";
 #endif
     searchPath = FileUtils::GetFullPath(searchPath);
-    s_pythonPath = FileUtils::LocateFileRecursive(searchPath, pythonExecName);
+    auto candidate = FileUtils::LocateFileRecursive(searchPath, pythonExecName);
+    if (!candidate.empty()) {
+      std::error_code ec;
+      auto perms = std::filesystem::status(candidate, ec).permissions();
+      bool isUsable = !ec &&
+          (perms & std::filesystem::perms::owner_exec) !=
+              std::filesystem::perms::none;
+#ifdef __APPLE__
+      // Reject Linux ELF binaries that cannot run on macOS.
+      // The bundled envs/litex/ Python is built for Linux x86-64; on macOS
+      // QProcess would fail with "execve: Exec format error".
+      if (isUsable) {
+        std::ifstream f(candidate, std::ios::binary);
+        char magic[4]{};
+        f.read(magic, 4);
+        if (magic[0] == 0x7f && magic[1] == 'E' &&
+            magic[2] == 'L' && magic[3] == 'F') {
+          isUsable = false;
+        }
+      }
+#endif
+      if (isUsable) {
+        s_pythonPath = candidate;
+      }
+    }
   }
   return s_pythonPath;
 }

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -66,13 +66,20 @@ void IPGenerator::setIpOutputLocation(const std::string& moduleName, const std::
 }
 
 IPGenerator::IPGenerator(const std::filesystem::path& installDir, IPCatalog* catalog, Compiler* compiler): m_installDir(installDir), m_catalog(catalog), m_compiler(compiler) {
-  m_environment["PYTHONHOME"] = (EnvsPath() / "python3.8").string();
+  // Only set PYTHONHOME and LD_LIBRARY_PATH when the bundled envs directory
+  // actually exists.  When it doesn't (e.g. macOS builds without the litex
+  // environment), setting PYTHONHOME to a non-existent path poisons the
+  // fallback to system python3, causing "Failed to import encodings module".
+  auto pythonHome = EnvsPath() / "python3.8";
+  if (std::filesystem::is_directory(pythonHome)) {
+    m_environment["PYTHONHOME"] = pythonHome.string();
 #ifndef __WIN32
-  // IP Generator requires libffi.so.6 which is absent on ubuntu>=20.04
-  std::string ldLibraryPath = qgetenv("LD_LIBRARY_PATH").toStdString();
-  std::string newLdLibraryPath = (EnvsPath() / "python3.8" / "lib" / "os_libs").string();
-  m_environment["LD_LIBRARY_PATH"] = newLdLibraryPath + ":" + ldLibraryPath;
+    // IP Generator requires libffi.so.6 which is absent on ubuntu>=20.04
+    std::string ldLibraryPath = qgetenv("LD_LIBRARY_PATH").toStdString();
+    std::string newLdLibraryPath = (pythonHome / "lib" / "os_libs").string();
+    m_environment["LD_LIBRARY_PATH"] = newLdLibraryPath + ":" + ldLibraryPath;
 #endif
+  }
 }
 
 void IPGenerator::shareContext()


### PR DESCRIPTION
## Problem

All IP generator smoke tests fail on macOS with `execve: Exec format error`:
- `ip_fifo_generator`
- `ip_on_chip_memory`
- `ip_dsp_generator`

## Root Cause

`IPCatalog::getPythonPath()` finds the bundled Python at `envs/litex/bin/python3`, which is a **Linux x86-64 ELF binary**. On macOS, QProcess tries to execve it, and the kernel rejects it with `Exec format error`.

Since `getPythonPath()` returns a non-empty path, the fallback to system `python3` in `buildLiteXIPFromGenerator()` never triggers.

## Fix

After locating the candidate Python binary:
1. Verify it has the execute permission bit set
2. On macOS (`__APPLE__`), read the first 4 bytes to detect ELF magic (`\x7fELF`) and reject Linux binaries

When rejected, `getPythonPath()` returns empty, triggering the existing fallback to system `python3`.

## Testing

Tested on macOS arm64 (Apple Silicon) with Aurora2 smoke tests. Before fix: 3 IP tests FAIL. After fix: IP tests use system python3 and proceed correctly.