### PR TITLE
fix: remove stale CRFileCryptProc include from QLSettingsManager

### DIFF
--- a/src/Compiler/QLSettingsManager.cpp
+++ b/src/Compiler/QLSettingsManager.cpp
@@ -24,7 +24,6 @@
 #include <regex>
 #include <filesystem>
 
-#include <CRFileCryptProc.hpp>
 #include "CompilerOpenFPGA_ql.h"
 #include "Compiler/Compiler.h"
 #include "Utils/FileUtils.h"


### PR DESCRIPTION
## Summary
Removes the obsolete `#include <CRFileCryptProc.hpp>` from `QLSettingsManager.cpp`.
This header no longer exists after the qlcrypt migration and causes build failures.

## Changes
- `src/Compiler/QLSettingsManager.cpp`: delete one stale include line

## Validation
- Aurora2 top-level build completes on macOS (arm64, clang)
- encrypt_device TURNKEY-FPGA3030 runs successfully with this fix applied

## Context
Part of cross-repo integration branch `1783-crr-encryption-e2e`.