### PR TITLE
Add DSPv2 synthesis option support

### DIFF
--- a/etc/settings/settings_test.json
+++ b/etc/settings/settings_test.json
@@ -162,6 +162,11 @@
                 "widgetType": "checkbox",
                 "arg": "no_bram"
             },
+            "dspv2_checkbox": {
+                "label": "Use DSPv2 Inference",
+                "widgetType": "checkbox",
+                "arg": "dspv2"
+            },
             "_META_": {
                 "hidden": false,
                 "isSetting": true,

--- a/examples/counter_16bit/counter_16bit.json
+++ b/examples/counter_16bit/counter_16bit.json
@@ -153,6 +153,13 @@
                 "widgetType": "checkbox",
                 "default": "unchecked",
                 "visible": true
+            },
+            "dspv2": {
+                "label": "Use DSPv2 Inference",
+                "text" : "dspv2",
+                "widgetType": "checkbox",
+                "default": "unchecked",
+                "visible": true
             }
         },
         "plugin": {}

--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -9344,6 +9344,11 @@ std::unordered_map<int, CommandWrapperPtr> CompilerOpenFPGA_ql::getSynthesisComm
     yosys_options += " -use_dsp_cfg_params";
   }
 
+  if( QLSettingsManager::getStringValue("yosys", "general", "dspv2") == "checked" ) {
+
+    yosys_options += " -dspv2";
+  }
+
   if( QLSettingsManager::getStringValue("yosys", "general", "synplify") == "checked"  || m_projManager->projectType() == PostMapSynplify || (m_projManager->projectType() == RTL && m_projManager->synthesisTool() == Synplify)) {
 
     yosys_options += " -synplify";


### PR DESCRIPTION
## Summary

Add support for the `-dspv2` yosys synthesis option to enable DSPv2 inference in the `synth_quicklogic` flow.

## Changes

### `src/Compiler/CompilerOpenFPGA_ql.cpp`
- Read the `dspv2` setting from the project configuration
- When enabled (`"checked"`), append `-dspv2` to yosys synthesis options
- This triggers DSPv2 cell inference during `synth_quicklogic` (loads `dspv2_sim.v`, `dspv2_map.v`, `dspv2_final_map.v` and runs the `QL_DSPV2_TYPES` pass)

### `etc/settings/settings_test.json`
- Add `dspv2_checkbox` widget to the settings UI for enabling DSPv2 synthesis

### `examples/counter_16bit/counter_16bit.json`
- Add `dspv2` checkbox option to the example project configuration

## Testing
- Verified 14 DSPv2 test designs synthesize correctly with this option
- All existing smoke tests pass unchanged
- DSPv2 is currently synthesis-only (PnR support pending VPR architecture model updates)

## Dependencies
- Requires corresponding `device_data` update: DSPv2 yosys library files (`dspv2_sim.v`, `dspv2_map.v`, `dspv2_final_map.v`) in K6N10 device directories