### PR TITLE
CompilerOpenFPGA_ql: add -dspv2 yosys synthesis option

### DIFF
--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -9315,6 +9315,11 @@ std::unordered_map<int, CommandWrapperPtr> CompilerOpenFPGA_ql::getSynthesisComm
     yosys_options += " -no_dsp";
   }
 
+  if( QLSettingsManager::getStringValue("yosys", "general", "dspv2") == "checked" ) {
+
+    yosys_options += " -dspv2";
+  }
+
   if( QLSettingsManager::getStringValue("yosys", "general", "no_bram") == "checked" ) {
 
     yosys_options += " -no_bram";


### PR DESCRIPTION
Adds a `dspv2` yosys general setting that appends `-dspv2` to the yosys `synth_quicklogic` options string.

This enables the yosys-driven DSPv2 inference flow (QuickLogic-Corp/yosys-f4pga-plugins branch `dspv2-partial-support`) where `synth_quicklogic -dspv2` no longer requires `-synplify`. The option is gated on the `yosys/general/dspv2` setting and defaults off, so existing flows are unaffected.

Inserted alongside the other yosys option toggles (next to `no_dsp`) in `CompilerOpenFPGA_ql.cpp`.