### PR TITLE
feat(bitstream): secure post-process — FOEDAG C++ integration layer

### DIFF
--- a/src/Compiler/Compiler.cpp
+++ b/src/Compiler/Compiler.cpp
@@ -1196,6 +1196,26 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           compiler->BitsOpt(Compiler::BitstreamOpt::Clean);
         } else if (arg == "enable_simulation") {
           compiler->BitsOpt(Compiler::BitstreamOpt::EnableSimulation);
+        } else if (arg == "encode") {
+          // Force the secure post-process this run (REQUIREMENTS.md §4.2).
+          compiler->SetBitstreamEncode(true);
+        } else if (arg == "checksum" || arg == "ascon" || arg == "bch") {
+          // Per-stage keywords are only valid after the `encode` verb.
+          if (!compiler->BitstreamEncode()) {
+            compiler->ErrorMessage("bitstream stage '" + arg +
+                                   "' requires 'encode' first");
+            return TCL_ERROR;
+          }
+          if (arg == "checksum") {
+            compiler->AddBitstreamEncodeStage(
+                Compiler::BitstreamEncodeStage::Checksum);
+          } else if (arg == "ascon") {
+            compiler->AddBitstreamEncodeStage(
+                Compiler::BitstreamEncodeStage::Ascon);
+          } else {
+            compiler->AddBitstreamEncodeStage(
+                Compiler::BitstreamEncodeStage::Bch);
+          }
         } else {
           compiler->ErrorMessage("Unknown bitstream option: " + arg);
         }
@@ -1549,6 +1569,26 @@ bool Compiler::RegisterCommands(TclInterpreter* interp, bool batchMode) {
           compiler->BitsOpt(Compiler::BitstreamOpt::Clean);
         } else if (arg == "enable_simulation") {
           compiler->BitsOpt(Compiler::BitstreamOpt::EnableSimulation);
+        } else if (arg == "encode") {
+          // Force the secure post-process this run (REQUIREMENTS.md §4.2).
+          compiler->SetBitstreamEncode(true);
+        } else if (arg == "checksum" || arg == "ascon" || arg == "bch") {
+          // Per-stage keywords are only valid after the `encode` verb.
+          if (!compiler->BitstreamEncode()) {
+            compiler->ErrorMessage("bitstream stage '" + arg +
+                                   "' requires 'encode' first");
+            return TCL_ERROR;
+          }
+          if (arg == "checksum") {
+            compiler->AddBitstreamEncodeStage(
+                Compiler::BitstreamEncodeStage::Checksum);
+          } else if (arg == "ascon") {
+            compiler->AddBitstreamEncodeStage(
+                Compiler::BitstreamEncodeStage::Ascon);
+          } else {
+            compiler->AddBitstreamEncodeStage(
+                Compiler::BitstreamEncodeStage::Bch);
+          }
         } else {
           compiler->ErrorMessage("Unknown bitstream option: " + arg);
         }

--- a/src/Compiler/Compiler.h
+++ b/src/Compiler/Compiler.h
@@ -104,6 +104,14 @@ class Compiler {
   enum class PowerOpt { None, Clean };
   enum class STAOpt { None, Clean, View };
   enum class BitstreamOpt { DefaultBitsOpt, Force, EnableSimulation, Clean };
+  // Combinable secure-encode stages, orthogonal to BitstreamOpt above (which is
+  // single-valued). `bitstream encode [checksum] [ascon] [bch]` ORs these.
+  enum class BitstreamEncodeStage : uint32_t {
+    None = 0,
+    Checksum = 1u << 0,
+    Ascon = 1u << 1,
+    Bch = 1u << 2,
+  };
   enum class STAEngineOpt { Tatum, Opensta };
 
   // Most common use case, create the compiler in your main
@@ -191,6 +199,17 @@ class Compiler {
 
   BitstreamOpt BitsOpt() const { return m_bitstreamOpt; }
   void BitsOpt(BitstreamOpt opt) { m_bitstreamOpt = opt; }
+  // Secure-encode (`bitstream encode ...`) request state for this run.
+  bool BitstreamEncode() const { return m_bitstreamEncode; }
+  void SetBitstreamEncode(bool value) { m_bitstreamEncode = value; }
+  uint32_t BitstreamEncodeStages() const { return m_bitstreamEncodeStages; }
+  void AddBitstreamEncodeStage(BitstreamEncodeStage stage) {
+    m_bitstreamEncodeStages |= static_cast<uint32_t>(stage);
+  }
+  void ResetBitstreamEncode() {
+    m_bitstreamEncode = false;
+    m_bitstreamEncodeStages = 0;
+  }
   // Compiler specific opt
   const std::string& SynthMoreOpt() { return m_synthMoreOpt; }
   void SynthMoreOpt(const std::string& opt) { m_synthMoreOpt = opt; }
@@ -341,6 +360,8 @@ class Compiler {
   STAOpt m_staOpt = STAOpt::None;
   STAEngineOpt m_staEngineOpt = STAEngineOpt::Tatum;
   BitstreamOpt m_bitstreamOpt = BitstreamOpt::DefaultBitsOpt;
+  bool m_bitstreamEncode = false;
+  uint32_t m_bitstreamEncodeStages = 0;
   std::filesystem::path m_PinMapCSV{};
   DeviceData m_deviceData;
 

--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -1406,7 +1406,11 @@ std::vector<std::string> CompilerOpenFPGA_ql::GetCleanFiles(
                "report_unconstrained_timing.hold.rpt",
                "report_unconstrained_timing.setup.rpt",
                "vpr_stdout.log",
-               BITSTREAM_LOG};
+               BITSTREAM_LOG,
+               // secure post-process artefacts (REQUIREMENTS.md §4.3, FR-9)
+               std::string{projectName + "_fabric_bitstream.bch"},
+               std::string{projectName + "_fabric_bitstream.ascon"},
+               std::string{projectName + "_bitstream_encode.log"}};
       break;
     default:
       break;
@@ -6244,6 +6248,31 @@ bool CompilerOpenFPGA_ql::GenerateBitstream() {
     ErrorMessage(std::string(__func__) + std::string("(): Design needs to be *atleast* in routed state"));
     return false;
   }
+  // `bitstream encode` (Tcl verb): run the secure post-process over an EXISTING
+  // fabric_bitstream.bit only -- do NOT re-run OpenFPGA, and bypass the
+  // bitstream_generation gate below (REQUIREMENTS.md §4.2, OQ-1).
+  if (BitstreamEncode()) {
+    const std::filesystem::path fabricBit =
+        std::filesystem::path(ProjManager()->projectPath()) /
+        "fabric_bitstream.bit";
+    if (!FileUtils::FileExists(fabricBit)) {
+      ErrorMessage(
+          "bitstream encode: fabric_bitstream.bit not found. Run 'bitstream' "
+          "first to generate it.");
+      ResetBitstreamEncode();
+      return false;
+    }
+    const uint32_t stages = ResolveBitstreamEncodeStages();
+    if (stages != 0) {
+      (void)RunBitstreamEncode(stages);
+    } else {
+      Message("bitstream encode: no stages enabled; nothing to do.");
+    }
+    ResetBitstreamEncode();
+    m_state = State::BistreamGenerated;
+    return true;
+  }
+
   Message("##################################################");
   Message("Bitstream generation for design \"" + ProjManager()->projectName() +
           "\" on device \"" + QLDeviceManager::getInstance()->getCurrentDeviceTargetString() + "\"");
@@ -6468,10 +6497,204 @@ int status = ExecuteAndMonitorSystemCommand(command);
                  " bitstream generation failed");
     return false;
   }
+  // Secure bitstream post-process (REQUIREMENTS.md §4): checksum -> ASCON -> BCH.
+  // Runs only if a stage is enabled via the settings JSON or forced via the
+  // `bitstream encode` Tcl verb. A post-process failure is logged but does NOT
+  // fail bitstream generation, since the plain fabric_bitstream.bit is valid
+  // (§4.5). The encode request state is cleared so it does not leak to the next
+  // bitstream run.
+  const uint32_t encodeStages = ResolveBitstreamEncodeStages();
+  if (encodeStages != 0) {
+    (void)RunBitstreamEncode(encodeStages);
+  }
+  ResetBitstreamEncode();
+
   m_state = State::BistreamGenerated;
 
   Message("Design " + ProjManager()->projectName() + " bitstream is generated.\n");
   
+  return true;
+}
+
+uint32_t CompilerOpenFPGA_ql::ResolveBitstreamEncodeStages() const {
+  // Device-capability gate: for checkbox settings, getStringValue() returns ""
+  // when the key is absent from the project JSON (which is a copy of the device
+  // settings_template.json), and "checked"/"unchecked" when it is present.
+  // If none of the three encoding keys exist in the project settings, the
+  // device's template does not declare encryption support — block all encoding
+  // paths, including the explicit `bitstream encode` Tcl verb.
+  auto keyPresent = [](const char* key) {
+    return !QLSettingsManager::getStringValue("openfpga", "general", key)
+                .empty();
+  };
+  if (!keyPresent("checksum_encoding") && !keyPresent("ascon_encoding") &&
+      !keyPresent("bch_encoding")) {
+    if (BitstreamEncode()) {
+      Message(
+          "bitstream encode: device settings do not include encryption keys; "
+          "secure encoding is not supported for this device.");
+    }
+    return 0;
+  }
+
+  auto checked = [](const char* key) {
+    return QLSettingsManager::getStringValue("openfpga", "general", key) ==
+           std::string("checked");
+  };
+  uint32_t jsonStages = 0;
+  if (checked("checksum_encoding"))
+    jsonStages |=
+        static_cast<uint32_t>(Compiler::BitstreamEncodeStage::Checksum);
+  if (checked("ascon_encoding"))
+    jsonStages |= static_cast<uint32_t>(Compiler::BitstreamEncodeStage::Ascon);
+  if (checked("bch_encoding"))
+    jsonStages |= static_cast<uint32_t>(Compiler::BitstreamEncodeStage::Bch);
+
+  if (BitstreamEncode()) {
+    // `bitstream encode <stage>...` forces exactly the named stages; bare
+    // `bitstream encode` honours the JSON toggles (REQUIREMENTS.md §4.2).
+    const uint32_t forced = BitstreamEncodeStages();
+    return forced != 0 ? forced : jsonStages;
+  }
+  // Plain `bitstream`: the bitstream_generation gate was already checked.
+  return jsonStages;
+}
+
+bool CompilerOpenFPGA_ql::RunBitstreamEncode(uint32_t stages) {
+  const std::filesystem::path projectPath(ProjManager()->projectPath());
+  const std::string projectName = ProjManager()->projectName();
+
+  // Vendored encoder, resolved via the same scripts root as other utilities.
+  const std::filesystem::path script =
+      GetSession()->Context()->DataPath() / std::filesystem::path("..") /
+      std::filesystem::path("scripts") / std::filesystem::path("bitstream") /
+      std::filesystem::path("aurora_bitstream_encode.py");
+
+#ifdef _WIN32
+  std::filesystem::path python_exec{"python.exe"};
+#else   // _WIN32
+  std::filesystem::path python_exec{"python3"};
+#endif  // _WIN32
+  if (!FileUtils::IsSystemCommandAvailable(python_exec.string())) {
+    ErrorMessage("System " + python_exec.string() +
+                 " not found; skipping secure bitstream post-process.");
+    return false;
+  }
+
+  const std::filesystem::path inp = projectPath / "fabric_bitstream.bit";
+  const std::filesystem::path out =
+      projectPath / (projectName + "_fabric_bitstream.bch");
+  const std::filesystem::path encFile =
+      projectPath / (projectName + "_fabric_bitstream.ascon");
+  const std::filesystem::path tagFile =
+      projectPath / (projectName + "_fabric_bitstream.tag");
+  std::filesystem::path xml = projectPath / "bitstream_distribution.xml";
+  const std::filesystem::path log =
+      projectPath / (projectName + "_bitstream_encode.log");
+
+  const bool doChecksum =
+      stages & static_cast<uint32_t>(Compiler::BitstreamEncodeStage::Checksum);
+  const bool doAscon =
+      stages & static_cast<uint32_t>(Compiler::BitstreamEncodeStage::Ascon);
+  const bool doBch =
+      stages & static_cast<uint32_t>(Compiler::BitstreamEncodeStage::Bch);
+
+  // If checksum is requested but the distribution XML is not in the project
+  // output directory, fall back to the device data copy. Without this file the
+  // Python encoder silently skips the checksum stage, producing a BCH without
+  // checksum rows that will fail hardware programming.
+  if (doChecksum && !std::filesystem::exists(xml)) {
+    const QLDeviceTarget device_target =
+        QLDeviceManager::getInstance()->getCurrentDeviceTarget();
+    const std::filesystem::path deviceXml =
+        QLDeviceManager::getInstance()->deviceTypeDirPath(device_target) /
+        "bitstream_distribution.xml";
+    if (std::filesystem::exists(deviceXml)) {
+      Message("bitstream encode: bitstream_distribution.xml not in project "
+              "dir; using device data copy.");
+      xml = deviceXml;
+    }
+  }
+
+  std::string stageNames;
+  if (doChecksum) stageNames += " checksum";
+  if (doAscon)    stageNames += " ascon";
+  if (doBch)      stageNames += " bch";
+
+  const std::string command = python_exec.string();
+  std::vector<std::string> args;
+  args.push_back(script.string());
+  args.push_back("--inp");
+  args.push_back(inp.string());
+  args.push_back("--out");
+  args.push_back(out.string());
+  if (doAscon) {
+    args.push_back("--enc");
+    args.push_back(encFile.string());
+    // Tag is an internal artifact (not exposed in GUI) used for software
+    // decode and roundtrip verification. Written alongside .bch and .ascon.
+    args.push_back("--tag");
+    args.push_back(tagFile.string());
+  }
+  if (doChecksum) {
+    args.push_back("--xml");
+    args.push_back(xml.string());
+  }
+  args.push_back("--log");
+  args.push_back(log.string());
+  if (doChecksum) args.push_back("--checksum");
+  if (doAscon)    args.push_back("--ascon");
+  if (doBch)      args.push_back("--bch");
+
+  // Advanced knobs default to driver values when the settings are absent.
+  const std::string padbits = QLSettingsManager::getStringValue(
+      "openfpga", "general", "bch_input_padbits");
+  if (!padbits.empty()) {
+    args.push_back("--input_padbits");
+    args.push_back(padbits);
+  }
+  const std::string just =
+      QLSettingsManager::getStringValue("openfpga", "general", "bch_input_just");
+  if (!just.empty()) {
+    args.push_back("--input_just");
+    args.push_back(just);
+  }
+
+  // Production key injection: when a device settings_template.json provides
+  // key file paths the encoder uses them; otherwise it falls back to the
+  // vendored non-secret sample keys (scripts/bitstream/sample_keys/).
+  if (doAscon) {
+    const std::string asconKey =
+        QLSettingsManager::getStringValue("openfpga", "general", "ascon_key_file");
+    if (!asconKey.empty()) {
+      args.push_back("--ascon_key");
+      args.push_back(asconKey);
+    }
+    const std::string asconNonce =
+        QLSettingsManager::getStringValue("openfpga", "general", "ascon_nonce_file");
+    if (!asconNonce.empty()) {
+      args.push_back("--ascon_nonce");
+      args.push_back(asconNonce);
+    }
+    const std::string asconAd =
+        QLSettingsManager::getStringValue("openfpga", "general", "ascon_ad_file");
+    if (!asconAd.empty()) {
+      args.push_back("--ascon_ad");
+      args.push_back(asconAd);
+    }
+  }
+
+  Message("Secure bitstream post-process [" + stageNames.substr(1) + "]: " +
+          command + " " + script.string());
+  const int status =
+      FileUtils::ExecuteSystemCommand(command, args, m_out, -1).realCode;
+  if (status != 0) {
+    // Non-fatal: the plain fabric_bitstream.bit is still valid (§4.5).
+    ErrorMessage("Secure bitstream post-process failed (see " + log.string() +
+                 "). The plain fabric_bitstream.bit is unaffected.");
+    return false;
+  }
+  Message("Secure bitstream written: " + out.string());
   return true;
 }
 

--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -6588,7 +6588,18 @@ bool CompilerOpenFPGA_ql::RunBitstreamEncode(uint32_t stages) {
       projectPath / (projectName + "_fabric_bitstream.ascon");
   const std::filesystem::path tagFile =
       projectPath / (projectName + "_fabric_bitstream.tag");
-  std::filesystem::path xml = projectPath / "bitstream_distribution.xml";
+  // The distribution XML filename defaults to "bitstream_distribution.xml" but
+  // a user-supplied value in settings supersedes it. An absolute path is used
+  // as-is; a bare filename is resolved against the project output dir (and the
+  // device data copy in the fallback below).
+  const std::string xmlSetting = QLSettingsManager::getStringValue(
+      "openfpga", "general", "bitstream_distribution_xml");
+  const std::string xmlName = xmlSetting.empty()
+                                  ? std::string("bitstream_distribution.xml")
+                                  : xmlSetting;
+  std::filesystem::path xml = std::filesystem::path(xmlName).is_absolute()
+                                  ? std::filesystem::path(xmlName)
+                                  : projectPath / xmlName;
   const std::filesystem::path log =
       projectPath / (projectName + "_bitstream_encode.log");
 
@@ -6608,10 +6619,11 @@ bool CompilerOpenFPGA_ql::RunBitstreamEncode(uint32_t stages) {
         QLDeviceManager::getInstance()->getCurrentDeviceTarget();
     const std::filesystem::path deviceXml =
         QLDeviceManager::getInstance()->deviceTypeDirPath(device_target) /
-        "bitstream_distribution.xml";
+        std::filesystem::path(xmlName).filename();
     if (std::filesystem::exists(deviceXml)) {
-      Message("bitstream encode: bitstream_distribution.xml not in project "
-              "dir; using device data copy.");
+      Message("bitstream encode: " +
+              std::filesystem::path(xmlName).filename().string() +
+              " not in project dir; using device data copy.");
       xml = deviceXml;
     }
   }

--- a/src/Compiler/CompilerOpenFPGA_ql.h
+++ b/src/Compiler/CompilerOpenFPGA_ql.h
@@ -187,6 +187,13 @@ class CompilerOpenFPGA_ql : public Compiler {
   bool TimingAnalysisHelper(const QLDeviceTarget&, const std::string&);
   virtual bool PowerAnalysis();
   virtual bool GenerateBitstream();
+  // Secure bitstream post-process (checksum -> ASCON -> BCH). Resolve which
+  // stages to run from the settings JSON toggles and the `bitstream encode`
+  // Tcl verb; run the vendored scripts/bitstream/aurora_bitstream_encode.py.
+  // A post-process failure is logged but does not fail GenerateBitstream
+  // (REQUIREMENTS.md §4.5). Returns false only on a hard invocation error.
+  uint32_t ResolveBitstreamEncodeStages() const;
+  [[nodiscard]] bool RunBitstreamEncode(uint32_t stages);
   bool GeneratePinConstraints(std::string& filepath_fpga_fix_pins_place_str);
   bool GenerateIOFloorPlanConstraints(bool forceOverwrite = false);
   virtual bool LoadDeviceData(const std::string& deviceName);


### PR DESCRIPTION
## Secure bitstream post-process — FOEDAG C++ integration layer

FOEDAG side of the Aurora secure bitstream feature (companion: aurora2 PR #1915).
Adds the C++ glue that invokes the Python encoder after the OpenFPGA bitstream step.

### What FOEDAG adds

After `fabric_bitstream.bit` is generated, Aurora calls `RunBitstreamEncode()` which
builds and invokes `aurora_bitstream_encode.py` with the stages and options resolved
from the device project settings:

    checksum → ASCON-128 encryption → BCH(511,484) ECC → <design>_fabric_bitstream.bch

Stage selection is driven by three `settings_template.json` checkboxes:
`checksum_encoding`, `ascon_encoding`, `bch_encoding` — all off by default.
If none are present in the device template, encoding is skipped entirely.

### Args wired through to the encoder

| Encoder arg | Source |
|---|---|
| `--checksum / --ascon / --bch` | Stage flags from settings |
| `--inp / --out / --enc / --log` | Fixed project-dir paths |
| `--tag` | Always written alongside `.bch` when ASCON is on (internal artifact for decode verification) |
| `--xml` | Project dir; falls back to device data copy when absent |
| `--ascon_key / --nonce / --ad` | `ascon_key_file` / `ascon_nonce_file` / `ascon_ad_file` settings fields; omitted → encoder uses vendored sample keys |
| `--input_padbits / --input_just` | `bch_input_padbits` / `bch_input_just` settings fields |

### Files changed

| File | Change |
|---|---|
| `src/Compiler/CompilerOpenFPGA_ql.cpp` | `ResolveBitstreamEncodeStages()` + `RunBitstreamEncode()` |
| `src/Compiler/CompilerOpenFPGA_ql.h` | `BitstreamEncodeStage` enum + `RunBitstreamEncode` declaration |

The encoder script (`aurora_bitstream_encode.py`) lives in the aurora2 repo.