### PR TITLE
Remove skip parameter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 	url = https://github.com/gtkwave/gtkwave.git
 [submodule "third_party/qlcrypt"]
 	path = third_party/qlcrypt
-	url = git@github.com:QL-Proprietary/qlcrypt.git
+	url = https://github.com/QL-Proprietary/qlcrypt.git
 	branch = master

--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -9710,7 +9710,6 @@ CommandWrapperPtr CompilerOpenFPGA_ql::getRoutingCommand()
     command->append(vpr_found_router_initial_acc_cost_chan_congestion_weight_param_string);
   }
 
-  command->append("--skip_sync_clustering_and_routing_results on");
   command->append("--route");
 
   return command;


### PR DESCRIPTION
Given that the VPR code has been updated to avoid running analysis when only routing is run, we no longer need to pass the skip parameter to routing.
