### PR TITLE
Do not encrypt config.json in CRR device packaging

### DIFF
--- a/src/Compiler/QLDeviceManager.cpp
+++ b/src/Compiler/QLDeviceManager.cpp
@@ -1976,12 +1976,6 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
               continue;  // prevent matching further copy rules
           }
 
-          // include config.json for encryption (CRR config contains device IP details)
-          if (dir_entry.path().filename().string() == "config.json") {
-              source_device_data_file_list_to_encrypt.push_back(dir_entry.path().string());
-              continue;  // prevent matching the generic .json copy rule below
-          }
-
           // include all files in 'examples/' for copy
           if (std::regex_match(dir_entry.path().string(),
                                 std::regex(R"(.+[\/\\]examples[\/\\].*)",
@@ -2326,7 +2320,7 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
     }
 
     // Post-encryption audit: for CRR devices, the target must not contain any
-    // plaintext copies of IP-sensitive files (SB_MAPS.yml, CSV/*.csv, config.json).
+    // plaintext copies of IP-sensitive files (SB_MAPS.yml, CSV/*.csv).
     // This catches classification bugs where a file ends up on both the encrypt
     // list (producing .en) and the copy list (producing a plaintext).
     {
@@ -2356,8 +2350,7 @@ int QLDeviceManager::encryptDevice(std::string family, std::string foundry, std:
         const bool is_csv_in_csv_dir = std::regex_match(
             fullpath,
             std::regex(R"(.+[\/\\]CSV[\/\\].*\.csv)", std::regex::icase));
-        const bool is_config_json = (fname == "config.json");
-        if (is_sb_maps || is_csv_in_csv_dir || is_config_json) {
+        if (is_sb_maps || is_csv_in_csv_dir) {
           residual_plaintext.push_back(fullpath);
         }
       }
@@ -2555,26 +2548,17 @@ std::filesystem::path QLDeviceManager::deviceConfigJSONPath(QLDeviceTarget devic
   }
   else {
 
-    // accept encrypted variant: config.json.en (decryption is performed in-memory
-    // by callers via loadDeviceConfigJSON()).
-    std::filesystem::path device_config_json_en_path = 
-        deviceTypeDirPath(device_target) / std::string("config.json.en");
-    if(FileUtils::FileExists(device_config_json_en_path)) {
-      device_config_json_path = device_config_json_en_path;
-    }
-    else {
-      // file does not exist!
-      device_config_json_path.clear();
-    }
+    // file does not exist!
+    device_config_json_path.clear();
   }
 
   return device_config_json_path;
 }
 
 
-// Load the device's `config.json` (plaintext or encrypted `.en`) into the
-// supplied json object. Returns true on success, false if neither variant
-// exists, decryption fails, or parsing fails.
+// Load the device's `config.json` into the supplied json object.
+// Returns true on success, false if the file does not exist or parsing fails.
+// config.json is always plaintext device data; it is never encrypted.
 bool QLDeviceManager::loadDeviceConfigJSON(QLDeviceTarget device_target, json& out_config_json) {
 
   if( !isDeviceTargetValid(device_target) ) {
@@ -2582,62 +2566,20 @@ bool QLDeviceManager::loadDeviceConfigJSON(QLDeviceTarget device_target, json& o
   }
 
   std::filesystem::path device_type_dir = deviceTypeDirPath(device_target);
-  std::filesystem::path plaintext_path  = device_type_dir / std::string("config.json");
+  std::filesystem::path config_json_path = device_type_dir / std::string("config.json");
 
-  // 1. Plaintext path: present in dev/source trees and in legacy/unencrypted devices.
-  if(FileUtils::FileExists(plaintext_path)) {
-    try {
-      std::ifstream ifs(plaintext_path.string());
-      out_config_json = json::parse(ifs);
-      return true;
-    }
-    catch(const std::exception& e) {
-      std::cout << "loadDeviceConfigJSON: failed to parse "
-                << plaintext_path.string() << ": " << e.what() << std::endl;
-      return false;
-    }
-  }
-
-  // 2. Encrypted variant: decrypt in-memory using <deviceTypeString>_Supp.db
-  std::filesystem::path encrypted_path = device_type_dir / std::string("config.json.en");
-  if(!FileUtils::FileExists(encrypted_path)) {
-    return false;
-  }
-
-  std::filesystem::path cryptdb_path = device_type_dir /
-      (DeviceTypeString(device_target.device_variant.family,
-                        device_target.device_variant.foundry,
-                        device_target.device_variant.node,
-                        device_target.device_variant.devicename) + "_Supp.db");
-
-  if(!FileUtils::FileExists(cryptdb_path)) {
-    std::cout << "loadDeviceConfigJSON: cryptdb not found alongside encrypted config: "
-              << cryptdb_path.string() << std::endl;
-    return false;
-  }
-
-  qlcrypt::KeyDB keys;
-  if(auto s = qlcrypt::KeyDB::load(cryptdb_path.string(), keys); !qlcrypt::ok(s)) {
-    std::cout << "loadDeviceConfigJSON: load cryptdb failed (" << cryptdb_path.string()
-              << "): " << qlcrypt::toString(s) << std::endl;
-    return false;
-  }
-
-  qlcrypt::FileCrypt fc(keys);
-  std::string plaintext;
-  if(auto s = fc.decryptFile(encrypted_path.string(), plaintext); !qlcrypt::ok(s)) {
-    std::cout << "loadDeviceConfigJSON: decrypt failed (" << encrypted_path.string()
-              << "): " << qlcrypt::toString(s) << std::endl;
+  if(!FileUtils::FileExists(config_json_path)) {
     return false;
   }
 
   try {
-    out_config_json = json::parse(plaintext);
+    std::ifstream ifs(config_json_path.string());
+    out_config_json = json::parse(ifs);
     return true;
   }
   catch(const std::exception& e) {
-    std::cout << "loadDeviceConfigJSON: failed to parse decrypted "
-              << encrypted_path.string() << ": " << e.what() << std::endl;
+    std::cout << "loadDeviceConfigJSON: failed to parse "
+              << config_json_path.string() << ": " << e.what() << std::endl;
     return false;
   }
 }

--- a/src/Compiler/QLDeviceManager.h
+++ b/src/Compiler/QLDeviceManager.h
@@ -169,12 +169,9 @@ class QLDeviceManager : public QObject {
 
   bool deviceFileIsEncrypted(std::filesystem::path filepath);
 
-  // Load the device's `config.json`, transparently handling the encrypted
-  // `config.json.en` variant (decrypted in-memory via qlcrypt using the
-  // `<deviceTypeString>_Supp.db` keystore alongside the file).
-  // Returns true on success and populates `out_config_json`.
-  // Returns false if neither plaintext nor `.en` file is present, or if
-  // decryption / JSON parsing fails.
+  // Load the device's plaintext `config.json` into `out_config_json`.
+  // config.json is device data and is never encrypted.
+  // Returns true on success; false if the file is absent or JSON parsing fails.
   bool loadDeviceConfigJSON(QLDeviceTarget device_target, json& out_config_json);
 
   std::filesystem::path deviceConfigJSONPath(QLDeviceTarget device_target = QLDeviceTarget());


### PR DESCRIPTION
## Summary

Follow-up to #171. That PR added `config.json` to the CRR device-encryption path, producing a `config.json.en` in the packaged device tree. **`config.json` should not be encrypted** — it is plaintext device-data metadata, and nothing consumes it in encrypted form.

### Why config.json must stay plaintext

- **VPR never reads it.** The VPR CLI contract from VTR-QL #48 consumes only the encrypted CRR artifacts: `--sb_maps <...>.en`, `--sb_templates`, `--crypt_key_db`. There is zero `config.json` reference anywhere in `vpr/`. Encrypting it serves no functional purpose in the CRR chain.
- **It broke AUTO-layout.** The `FPGA_AUTO` → layout-name substitution (`CompilerOpenFPGA_ql.cpp`) scans for plaintext `*.json` and would silently skip a `config.json.en`, leaving the placeholder unsubstituted.

### Changes (all in `QLDeviceManager.cpp`/`.h`)

- **`encryptDevice`** — removed the dedicated rule that routed `config.json` onto the encrypt list. It now falls through to the existing generic `.json` copy rule and is shipped as plaintext (pre-#171 behavior).
- **Post-encryption audit** — no longer flags a plaintext `config.json` as a residual-plaintext leak. The audit still enforces no plaintext `SB_MAPS.yml` / `CSV/*.csv`.
- **`loadDeviceConfigJSON` / `deviceConfigJSONPath`** — removed the `config.json.en` decryption/fallback path; `config.json` is read as plaintext only.

Untouched: `deviceFileIsEncrypted` (`QLEN` magic detection) and all qlcrypt usage for the **legitimate** encrypted CRR artifacts (`SB_MAPS.yml`, `CSV`, `xml`, `capnp`).

## Testing

- `QLDeviceManager.cpp` compiles clean.
- **Functional e2e**: ran `encrypt_device` on a real CRR device (`QLF_K6N10/GF/12nm/TURNKEY-FPGA3030`) and verified the packaged output:
  - `config.json` shipped **plaintext** (byte-identical to source, valid JSON) — no `config.json.en`.
  - `SB_MAPS.yml` → `SB_MAPS.yml.en`; all 90 `CSV/*.csv` → `.csv.en`; no plaintext IP files leaked.
  - Post-encryption audit **passed**; `_Supp.db` keystore produced.