### PR TITLE
Fix FOEDAG build under macOS AppleClang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,21 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 set(CMAKE_VERBOSE_MAKEFILE ON)
 
+if(APPLE)
+  # macOS toolchains (AppleClang) are newer/stricter than the supported
+  # Linux/Windows build toolchains and emit on-by-default warnings the
+  # project's per-subdirectory -Werror does not anticipate (e.g.
+  # -Winconsistent-missing-override, -Wmismatched-tags,
+  # -Wdeprecated-literal-operator). The per-subdirectory -Werror flags live
+  # in CMAKE_CXX_FLAGS_<CONFIG>, so the only place a suppression is
+  # guaranteed to land last (and win) is a directory compile option, which
+  # the compiler sees after those flag variables. Demote warnings to
+  # non-fatal on macOS only; warnings stay visible. Placed before the
+  # add_subdirectory() calls so it propagates to every target. APPLE-only:
+  # no effect on Linux or Windows builds.
+  add_compile_options(-Wno-error)
+endif()
+
 add_subdirectory(third_party/tcl_cmake EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/googletest EXCLUDE_FROM_ALL)
 add_subdirectory(third_party/QScintilla-2.13.1)

--- a/src/Utils/PathUtils.cpp
+++ b/src/Utils/PathUtils.cpp
@@ -9,6 +9,7 @@
 #endif
 
 #include <iostream>
+#include <sstream>
 
 namespace FOEDAG {
 


### PR DESCRIPTION
## Summary

Building FOEDAG on macOS with a recent AppleClang toolchain fails for two toolchain-strictness reasons, both unrelated to any feature change. This PR makes the macOS build pass without affecting Linux or Windows.

## Changes

1. **`src/Utils/PathUtils.cpp`** — `std::stringstream` was used with only `<iostream>` included. libc++ (macOS) does not transitively include `<sstream>`, so this is a hard compile error. Added the missing `#include <sstream>`. This is a correctness fix and a no-op on Linux/Windows (the header was already available transitively).

2. **`CMakeLists.txt`** — newer AppleClang emits on-by-default warnings the project's per-subdirectory `-Werror` does not anticipate (`-Winconsistent-missing-override`, `-Wmismatched-tags`, `-Wdeprecated-literal-operator` in the vendored `nlohmann/json` header). Because those `-Werror` flags live in `CMAKE_CXX_FLAGS_<CONFIG>`, the only place a suppression is guaranteed to be applied **last** (and win) is a directory compile option. Added `add_compile_options(-Wno-error)` guarded by `if(APPLE)`, placed before the `add_subdirectory()` calls so it propagates to every target. Warnings remain visible; they are simply non-fatal on macOS.

## Scope / safety

- Both changes are **macOS-only in effect**. The CMake block is `if(APPLE)`-guarded; the include is additive and already-satisfied elsewhere.
- No Linux or Windows compilation behavior changes.

## Testing

- Full `make release` on macOS (AppleClang 21, arm64, Qt5) now builds the `aurora`/FOEDAG binary cleanly to completion. Before these changes the build failed early (PathUtils `<sstream>` hard error, then `-Werror`-promoted warnings in isolated-flag subdirectories).