### PR TITLE
submodule(qlcrypt): point at public QuickLogic-Corp/qlcrypt (Apache-2.0)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,5 +6,5 @@
 	url = https://github.com/gtkwave/gtkwave.git
 [submodule "third_party/qlcrypt"]
 	path = third_party/qlcrypt
-	url = https://github.com/QL-Proprietary/qlcrypt.git
+	url = https://github.com/QuickLogic-Corp/qlcrypt.git
 	branch = master


### PR DESCRIPTION
## What

qlcrypt has been open-sourced at **https://github.com/QuickLogic-Corp/qlcrypt** under **Apache-2.0**. This updates the `third_party/qlcrypt` submodule:

- **URL**: `https://github.com/QL-Proprietary/qlcrypt.git` → `https://github.com/QuickLogic-Corp/qlcrypt.git`.
- **Re-pin**: `c20322a` → `709d24b`. The public repo has a fresh history, so the old private SHA does not exist there; re-pinning is required.

FOEDAG always links `qlcrypt::qlcrypt` (no build gate), so this stays a normal active submodule — only the URL and pin change.

Validated locally: `git submodule update --init third_party/qlcrypt` resolves `709d24b` from the public repo (Apache-2.0 LICENSE present).