### PR TITLE
fix(compiler): parametric (FPGA_AUTO/FPGA_CUSTOM) layout-generation flow under CRR encryption

### DIFF
--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -3347,6 +3347,50 @@ bool CompilerOpenFPGA_ql::Packing() {
     // Deal with the generated SB_MAPS yml:
     m_autoLayoutGeneratedSBMapsYMLPath = generated_sb_maps_yml_path;
 
+    // Keep the generated routing-graph set (SB_MAPS + CSV switchbox templates)
+    // internally consistent. The CSV templates are reused unchanged from the
+    // source device, so when they are encrypted (.en) the freshly generated
+    // SB_MAPS -- written in plaintext by add_layout.py -- must be encrypted to
+    // match. VPR selects CRR encrypted-vs-plaintext decoding solely off the
+    // '.en' suffix of --sb_maps; a plaintext --sb_maps would make VPR read the
+    // encrypted 'switchbox_*.csv.en' templates as plaintext and fail with
+    // "Required switch template file not found". Encrypting the generated
+    // SB_MAPS lets VPR decrypt SB_MAPS + CSV in-memory (keyed off the .en
+    // suffix + --crypt_key_db). Pin-table data is unrelated to CRR routing-graph
+    // encryption and is intentionally left untouched.
+    {
+      std::filesystem::path sb_templates_dir =
+          QLDeviceManager::getInstance()->deviceSBTemplatesDir();
+      bool csv_templates_encrypted = false;
+      std::error_code ec_csv;
+      if (!sb_templates_dir.empty() &&
+          std::filesystem::is_directory(sb_templates_dir, ec_csv)) {
+        for (const auto& entry :
+             std::filesystem::directory_iterator(sb_templates_dir, ec_csv)) {
+          if (entry.is_regular_file(ec_csv) &&
+              entry.path().extension() == ".en") {
+            csv_templates_encrypted = true;
+            break;
+          }
+        }
+      }
+      if (csv_templates_encrypted) {
+        std::vector<std::filesystem::path> sbmaps_to_encrypt;
+        sbmaps_to_encrypt.push_back(generated_sb_maps_yml_path);
+        if (!encryptDeviceFiles(
+                sbmaps_to_encrypt,
+                QLDeviceManager::getInstance()->deviceTypeDirPath(),
+                QLDeviceManager::getInstance()->convertToDeviceTypeString())) {
+          return false;
+        }
+        // Drop the plaintext generated SB_MAPS; downstream stages use the
+        // encrypted variant so VPR decrypts it (and the CSV templates) in-memory.
+        FileUtils::removeFile(generated_sb_maps_yml_path);
+        m_autoLayoutGeneratedSBMapsYMLPath = generated_sb_maps_yml_path;
+        m_autoLayoutGeneratedSBMapsYMLPath += ".en";
+      }
+    }
+
 
     // re-run packing with the generated vpr xml now.
     // easiest way is to take the previous command as is, and 
@@ -3493,6 +3537,16 @@ bool CompilerOpenFPGA_ql::Packing() {
       // SB_TEMPLATES dir is copied parallel to the vpr.xml.en (this is probably not required at all!, as it will remain same as current device.)
       std::filesystem::path target_device_sb_maps_yml_filepath =
           target_device_copy_dirpath / "aurora" / "SB_MAPS.yml";
+      // The generated SB_MAPS may have been encrypted (.en) to stay consistent
+      // with the device's encrypted CSV switchbox templates. Preserve that
+      // suffix on the copy so the regenerated device's SB_MAPS file name matches
+      // its (encrypted) content; deviceSBMAPSFile() resolves the '.en' variant
+      // and VPR keys CRR decryption off that suffix. Without this the cached
+      // device would carry encrypted bytes under a plaintext '.yml' name and
+      // fail to decrypt on reuse.
+      if(m_autoLayoutGeneratedSBMapsYMLPath.extension() == ".en") {
+        target_device_sb_maps_yml_filepath += ".en";
+      }
       FileUtils::overwriteFile(m_autoLayoutGeneratedSBMapsYMLPath, target_device_sb_maps_yml_filepath);
 
       // 4 cryptdb: replace FPGA_AUTO with the generated layout name

--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -3374,7 +3374,12 @@ bool CompilerOpenFPGA_ql::Packing() {
           }
         }
       }
-      if (csv_templates_encrypted) {
+      // Only encrypt when a generated SB_MAPS actually exists. Some paths (e.g.
+      // the auto-layout "design fits the base layout" case) may not produce a
+      // generated SB_MAPS; encrypting a missing file would hard-fail here. A
+      // missing SB_MAPS is handled (and reported) by the downstream stages.
+      if (csv_templates_encrypted &&
+          FileUtils::FileExists(generated_sb_maps_yml_path)) {
         std::vector<std::filesystem::path> sbmaps_to_encrypt;
         sbmaps_to_encrypt.push_back(generated_sb_maps_yml_path);
         if (!encryptDeviceFiles(

--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -3354,12 +3354,19 @@ bool CompilerOpenFPGA_ql::Packing() {
     // - replace the layout name
     std::string command_rerun = command->string();
 
-    // ensure that 'FPGA_AUTO' replacement is done first!!
+    // Replace ONLY the '--device <layout>' token, not every occurrence of the
+    // layout name. The command also embeds device-data PATHS such as
+    // '.../TURNKEY-FPGA_AUTO/.../vpr.xml' and the sdc/net file paths, which must
+    // keep pointing at the original device directory. A blunt ReplaceAll on the
+    // bare layout name rewrote those paths to a non-existent
+    // 'TURNKEY-AUTOFPGA<w><h>' directory (in plaintext mode the arch path is the
+    // on-disk device file), so the architecture-file swap below could no longer
+    // match old_m_architectureFile and VPR failed to open the arch file.
     if(m_autoLayoutGenerationMode) {
-      command_rerun = ReplaceAll(command_rerun, "FPGA_AUTO", m_autoLayoutGeneratedLayoutName);
+      command_rerun = ReplaceAll(command_rerun, "--device FPGA_AUTO", "--device " + m_autoLayoutGeneratedLayoutName);
     }
     if(m_customLayoutGenerationMode) {
-      command_rerun = ReplaceAll(command_rerun, "FPGA_CUSTOM", m_autoLayoutGeneratedLayoutName);
+      command_rerun = ReplaceAll(command_rerun, "--device FPGA_CUSTOM", "--device " + m_autoLayoutGeneratedLayoutName);
     }
     command_rerun = ReplaceAll(command_rerun, old_m_architectureFile.string(), m_architectureFile.string());
     // generator devices (AUTO/CUSTOM) may not ship a static SB_MAPS.yml, so the

--- a/src/Compiler/QLDeviceManager.cpp
+++ b/src/Compiler/QLDeviceManager.cpp
@@ -3742,7 +3742,13 @@ std::filesystem::path QLDeviceManager::deviceSBTemplatesDir(QLDeviceTarget devic
 
   if(compiler->m_autoLayoutGenerationMode ||
     compiler->m_customLayoutGenerationMode){
-    // no change in CSV, we can use the existing device's CSV unless something changes in the future.
+    // The CSV switchbox templates are reused unchanged from the source device,
+    // so we return its CSV directory as-is (encrypted or plaintext). To keep the
+    // generated routing-graph set consistent, the freshly generated SB_MAPS is
+    // encrypted to match these templates when they are encrypted -- see the
+    // generated-SB_MAPS handling in CompilerOpenFPGA_ql::Packing(). VPR selects
+    // CRR encrypted-vs-plaintext decoding off the --sb_maps '.en' suffix, so
+    // SB_MAPS and these templates must share the same encryption state.
   }
 
   if( !isDeviceTargetValid(device_target) ) {


### PR DESCRIPTION
## Summary

Fixes the auto/custom layout-generation flow (`FPGA_AUTO`, `FPGA_CUSTOM`) so it
completes pack→place→route in both plaintext and encrypted (CRR) device-data
configurations. These devices were failing the aurora2 `examples-sanity` flow.

This pairs with an aurora2-side change to `scripts/generate_floorplanning.py`
(skip — rather than fail — when a device has neither a pin table nor a QDC),
which unblocked the flow far enough to expose the issues fixed here.

## Changes

**1. Scope the generated-layout rename to the `--device` token** (`8e9c3fe2`)
The packing-rerun command was post-processed with
`ReplaceAll(cmd, "FPGA_AUTO"/"FPGA_CUSTOM", <generated layout name>)`. That blunt
substring replace also rewrote device-data **paths** embedded in the command
(e.g. `.../TURNKEY-FPGA_AUTO/.../vpr.xml`, sdc/net paths) to a non-existent
`TURNKEY-AUTOFPGA<w><h>` directory. In plaintext mode (where the arch path is the
on-disk device file) this corrupted `old_m_architectureFile` before the
subsequent arch-file swap could match it → `VPR: Failed to open file`. Now only
the `--device <layout>` token is replaced.

**2. Keep the generated routing-graph (SB_MAPS + CSV) encryption-consistent** (`72dc765f`)
For a generated device, `deviceSBMAPSFile()` returns the freshly generated
SB_MAPS (written in plaintext by `add_layout.py`) while `deviceSBTemplatesDir()`
returns the source device's CSV switchbox templates unchanged. For an encrypted
device those templates are `.en`, so VPR — which selects CRR encrypted-vs-plaintext
decoding solely off the `--sb_maps` `.en` suffix — took the plaintext path and
aborted with `Required switch template file not found: switchbox_*.csv`. The
generated SB_MAPS is now encrypted to match whenever the templates are encrypted
(detected by scanning the CSV dir for a `.en` file, so the decision tracks the
templates' actual state, not the on-disk key DB). The plaintext SB_MAPS is then
removed, so no plaintext CRR data is written to disk and VPR decrypts SB_MAPS +
CSV in-memory via `--crypt_key_db`. Plaintext devices keep `.csv` templates and a
plaintext SB_MAPS, so both remain consistent. The `.en` suffix is also preserved
when the generated SB_MAPS is copied into the regenerated (cached) device dir.

**3. Guard SB_MAPS encryption against a missing file** (`0741eb46`)
The generated SB_MAPS is not produced on every path — e.g. the auto-layout
"design fits the base layout" branch (small designs that route without CRR).
Only encrypt when the generated SB_MAPS actually exists, so the fits path is not
hard-failed by trying to encrypt a non-existent file.

## Scope / non-goals
- Pin-table data is unrelated to CRR routing-graph encryption and is left
  untouched.
- No change to fixed-device behaviour (devices that ship a pin table /
  static SB_MAPS).

## Testing
Local clean build of aurora2 + `make examples-sanity` (encryption on), all
in-scope targets pass:
- `FPGA_CUSTOM` minimal — plaintext 2/2, encrypted 2/2
- `FPGA_AUTO` minimal — encrypted 2/2 (both the "fits" and "doesn't-fit" paths)
- `FPGA3030` minimal — 9/9 (fixed-device regression, incl. pin-table floorplanning)
- `IDAHO-FPGA0806_WLBL` quick — 3/3