### PR TITLE
Reverting Timing Analysis Behavior in Routing Stage

### DIFF
--- a/src/Compiler/CompilerOpenFPGA_ql.cpp
+++ b/src/Compiler/CompilerOpenFPGA_ql.cpp
@@ -9770,6 +9770,8 @@ CommandWrapperPtr CompilerOpenFPGA_ql::getRoutingCommand()
     command->append(vpr_found_router_initial_acc_cost_chan_congestion_weight_param_string);
   }
 
+  command->append("--skip_sync_clustering_and_routing_results on");
+  command->append("--analysis");
   command->append("--route");
 
   return command;


### PR DESCRIPTION
> ### Summarize The PR
This PR ensures that timing analysis is running during the routing stage. This will prevent issues in metrics extraction.
> #### Describe the changes in the PR
