### PR TITLE
fix(IPA): replace VPR warning pop-ups with log-only output

### DIFF
--- a/src/InteractivePathAnalysis/NCriticalPathWidget.cpp
+++ b/src/InteractivePathAnalysis/NCriticalPathWidget.cpp
@@ -30,7 +30,6 @@
 #include <QHBoxLayout>
 #include <QHeaderView>
 #include <QLabel>
-#include <QMessageBox>
 #include <QPushButton>
 #include <QVBoxLayout>
 
@@ -148,15 +147,9 @@ void NCriticalPathWidget::requestPathList(const QString& initiator) {
 }
 
 void NCriticalPathWidget::notifyError(QString title, QString errorMsg) {
-  if (isVisible()) {
-    QMessageBox::warning(this, title, errorMsg, QMessageBox::Ok);
-  } else {
-    // if parent widget is not visible, the message box will behave as not a
-    // modal, to avoid this let's show message box with delay.
-    QTimer::singleShot(500, [=]() {
-      QMessageBox::warning(this, title, errorMsg, QMessageBox::Ok);
-    });
-  }
+  // VPR stderr is already logged by VprProcess; redirect here to the log
+  // rather than blocking the user with a modal dialog (issue #1992).
+  SimpleLogger::instance().error(title, errorMsg);
   if (!errorMsg.contains(": warning:")) {  // hide busy widget only on errors
                                            // but not on warnings
     m_view->hideBusyOverlay();

--- a/src/InteractivePathAnalysis/VprProcess.cpp
+++ b/src/InteractivePathAnalysis/VprProcess.cpp
@@ -51,7 +51,8 @@ Process::Process(const QString& name) : m_name(name) {
         break;
       }
     }
-    if (!skipUIReportingError) {
+    if (!skipUIReportingError && !m_seenErrors.contains(error)) {
+      m_seenErrors.insert(error);
       emit innerErrorOccurred(error);
     }
   });

--- a/src/InteractivePathAnalysis/VprProcess.h
+++ b/src/InteractivePathAnalysis/VprProcess.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <QProcess>
+#include <QSet>
 #include <QTimer>
 #include <vector>
 
@@ -77,6 +78,7 @@ class Process : public QProcess {
   QProcess::ProcessState m_prevState;
 
   std::vector<QString> m_bypassInnerErrors;
+  QSet<QString> m_seenErrors;
 
   void restart();
   void checkEvent();

--- a/tests/unittest/CMakeLists.txt
+++ b/tests/unittest/CMakeLists.txt
@@ -61,6 +61,7 @@ if (USE_IPA)
     InteractivePathAnalysis/TelegramParser_test.cpp
     InteractivePathAnalysis/TelegramBuffer_test.cpp
     InteractivePathAnalysis/NCriticalPathModel_test.cpp
+    InteractivePathAnalysis/VprProcess_test.cpp
   )
 endif()
 

--- a/tests/unittest/InteractivePathAnalysis/VprProcess_test.cpp
+++ b/tests/unittest/InteractivePathAnalysis/VprProcess_test.cpp
@@ -1,0 +1,136 @@
+/**
+  * @file VprProcess_test.cpp
+  * @author Oleksandr Pyvovarov (APivovarov@quicklogic.com or
+  aleksandr.pivovarov.84@gmail.com or
+  * https://github.com/w0lek)
+  * @date 2024-03-12
+  * @copyright Copyright 2021 The Foedag team
+
+  * GPL License
+
+  * Copyright (c) 2021 The Open-Source FPGA Foundation
+
+  * This program is free software: you can redistribute it and/or modify
+  * it under the terms of the GNU General Public License as published by
+  * the Free Software Foundation, either version 3 of the License, or
+  * (at your option) any later version.
+
+  * This program is distributed in the hope that it will be useful,
+  * but WITHOUT ANY WARRANTY; without even the implied warranty of
+  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  * GNU General Public License for more details.
+
+  * You should have received a copy of the GNU General Public License
+  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+// Verifies Process (VprProcess) error deduplication and bypass list behavior.
+// These tests run headless — Process is pure QProcess/signal, no widget needed.
+
+#include "InteractivePathAnalysis/VprProcess.h"
+
+#include <QCoreApplication>
+#include <QEventLoop>
+#include <QSignalSpy>
+#include <QTimer>
+
+#include "gtest/gtest.h"
+
+using namespace FOEDAG;
+
+namespace {
+
+// Run a Process with the given program/args, wait up to timeoutMs for it to
+// finish, and return all messages emitted via innerErrorOccurred.
+QStringList runAndCollect(const QString& program, const QStringList& args,
+                          const QStringList& bypass = {},
+                          int timeoutMs = 5000) {
+  Process proc("test");
+  for (const auto& b : bypass) proc.addInnerErrorToBypass(b);
+
+  QStringList collected;
+  QObject::connect(&proc, &Process::innerErrorOccurred,
+                   [&](QString msg) { collected << msg; });
+
+  proc.setProgram(program);
+  proc.setArguments(args);
+  proc.QProcess::start();
+
+  QEventLoop loop;
+  QObject::connect(&proc,
+                   QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished),
+                   &loop, &QEventLoop::quit);
+  QTimer::singleShot(timeoutMs, &loop, &QEventLoop::quit);
+  loop.exec();
+  // Drain any remaining async events (e.g. last readyReadStandardError)
+  QCoreApplication::processEvents(QEventLoop::AllEvents, 200);
+  return collected;
+}
+
+// Python3 one-liner that writes messages to stderr with explicit flushes and
+// small sleeps so Qt dispatches each as a separate readyReadStandardError event.
+QString stderrScript(const QStringList& lines) {
+  QStringList stmts;
+  for (int i = 0; i < lines.size(); ++i) {
+    stmts << QString("sys.stderr.write('%1\\n'); sys.stderr.flush()").arg(
+        lines[i]);
+    if (i < lines.size() - 1) stmts << "time.sleep(0.05)";
+  }
+  return "import sys,time; " + stmts.join("; ");
+}
+
+}  // namespace
+
+// Each unique message should fire innerErrorOccurred exactly once.
+TEST(VprProcess, UniqueMessagesEachFireOnce) {
+  QStringList msgs{"first_warning", "second_warning", "third_warning"};
+  auto collected = runAndCollect(
+      "python3", {"-c", stderrScript(msgs)});
+
+  ASSERT_EQ(3, collected.size());
+  EXPECT_TRUE(collected[0].contains("first_warning"));
+  EXPECT_TRUE(collected[1].contains("second_warning"));
+  EXPECT_TRUE(collected[2].contains("third_warning"));
+}
+
+// A message emitted twice to stderr must fire the signal only once (dedup).
+TEST(VprProcess, DuplicateMessageEmittedOnce) {
+  QStringList lines{"vpr_timing_warning", "vpr_timing_warning", "other_warning"};
+  auto collected = runAndCollect(
+      "python3", {"-c", stderrScript(lines)});
+
+  ASSERT_EQ(2, collected.size());
+  EXPECT_TRUE(collected[0].contains("vpr_timing_warning"));
+  EXPECT_TRUE(collected[1].contains("other_warning"));
+}
+
+// A message matching the bypass list must never fire innerErrorOccurred.
+TEST(VprProcess, BypassedMessageNotEmitted) {
+  QStringList lines{"GLib-GIO-WARNING **: accessibility bus error",
+                    "real_vpr_error"};
+  auto collected = runAndCollect(
+      "python3", {"-c", stderrScript(lines)},
+      /*bypass=*/{"GLib-GIO-WARNING **:"});
+
+  ASSERT_EQ(1, collected.size());
+  EXPECT_TRUE(collected[0].contains("real_vpr_error"));
+}
+
+// A bypassed message repeated multiple times must never fire the signal.
+TEST(VprProcess, BypassedDuplicateNeverEmitted) {
+  QStringList lines{"GTK_IS_LABEL error", "GTK_IS_LABEL error",
+                    "another_error"};
+  auto collected = runAndCollect(
+      "python3", {"-c", stderrScript(lines)},
+      /*bypass=*/{"GTK_IS_LABEL"});
+
+  ASSERT_EQ(1, collected.size());
+  EXPECT_TRUE(collected[0].contains("another_error"));
+}
+
+// When no stderr is produced, no signal should fire.
+TEST(VprProcess, NoStderrNoSignal) {
+  auto collected = runAndCollect(
+      "python3", {"-c", "import sys; sys.stdout.write('stdout only\\n')"});
+  EXPECT_EQ(0, collected.size());
+}


### PR DESCRIPTION
## Summary

Fixes QL-Proprietary/aurora2#1992.

- **Remove \`QMessageBox\` pop-ups for VPR stderr** — \`notifyError()\` in \`NCriticalPathWidget\` no longer calls \`QMessageBox::warning()\`; messages go to \`SimpleLogger\` instead (VPR stderr was already logged unconditionally by \`VprProcess\` before the bypass check, so the dialog was purely redundant)
- **Add per-session deduplication in \`VprProcess\`** — a \`QSet<QString> m_seenErrors\` ensures \`innerErrorOccurred\` is emitted at most once per unique message per session, preventing log spam
- **Remove unused \`#include <QMessageBox>\`** from \`NCriticalPathWidget.cpp\`
- **Add 5 headless unit tests** for \`VprProcess\` dedup and bypass behavior (run with \`QT_QPA_PLATFORM=offscreen\`, no display required)

### Why the old approach (blacklist bypass) was fragile

The bypass list contained 4 OS-level noise patterns (AppArmor, D-Bus, GTK, PWD). Any VPR stderr message not matching those patterns triggered a blocking modal dialog. VPR timing path analysis emits routine warnings that were never in the bypass list and will change with VPR versions — outpacing the blacklist permanently.

### What is preserved

- \`hideBusyOverlay()\` is still called on non-warning errors so the UI state remains correct
- All VPR stderr still reaches the SimpleLogger file for debugging

## Test plan

### Automated (headless)
```
QT_QPA_PLATFORM=offscreen ./build/tests/unittest/unittest --gtest_filter="VprProcess.*"
```
All 5 tests pass without a display.

### Manual (GUI)
- [ ] Open a project on QLSOF02 and launch critical timing path analysis
- [ ] Verify no warning pop-up dialogs appear during or after analysis
- [ ] Verify the timing path list loads normally
- [ ] Verify the SimpleLogger log file contains the VPR stderr messages that previously triggered pop-ups
- [ ] Trigger the analysis a second time — repeated warnings should appear only once in the log