### PR TITLE
IP catalog: device-gate FPU generators on FPU_TYPE capability

### DIFF
--- a/src/Compiler/QLDeviceManager.cpp
+++ b/src/Compiler/QLDeviceManager.cpp
@@ -2599,6 +2599,31 @@ std::string QLDeviceManager::deviceDSPVersion(QLDeviceTarget device_target) {
   return major + "_" + minor;
 }
 
+std::set<std::string> QLDeviceManager::deviceFPUTypes(QLDeviceTarget device_target) {
+
+  // The FPU IP family is gated by a capability set (not a version, unlike DSP).
+  // config.json carries "FPU_TYPE" as a JSON array of tokens, e.g.
+  //   "FPU_TYPE": ["FPUADDSUB", "FPUMULT", "FPUMAC"]
+  // Absent / empty / non-array => empty set (opt-in: the FPU IP stays hidden).
+  std::set<std::string> types;
+
+  json device_target_config_json;
+  if(loadDeviceConfigJSON(device_target, device_target_config_json)) {
+    if( device_target_config_json.contains("FPU_TYPE") ) {
+      const auto& fpu_type = device_target_config_json["FPU_TYPE"];
+      if( fpu_type.is_array() ) {
+        for( const auto& entry : fpu_type ) {
+          if( entry.is_string() ) {
+            types.insert(entry.get<std::string>());
+          }
+        }
+      }
+    }
+  }
+
+  return types;
+}
+
 // Load the device's `config.json` into the supplied json object.
 // Returns true on success, false if the file does not exist or parsing fails.
 // config.json is always plaintext device data; it is never encrypted.

--- a/src/Compiler/QLDeviceManager.h
+++ b/src/Compiler/QLDeviceManager.h
@@ -179,6 +179,11 @@ class QLDeviceManager : public QObject {
   // config.json. Returns "<major>_<minor>" (e.g. "DSPV2" -> "2_0",
   // "DSPV1.1" -> "1_1"). Defaults to "1_0" (DSPV1.0) when not specified.
   std::string deviceDSPVersion(QLDeviceTarget device_target = QLDeviceTarget());
+  // Set of FPU IP capability tokens the device supports, from the "FPU_TYPE"
+  // JSON string-array in config.json (e.g. {"FPUADDSUB","FPUMULT","FPUMAC"}).
+  // Returns an empty set when the key is absent, empty, or not a string array
+  // (opt-in gating: no token => the corresponding FPU IP is unavailable).
+  std::set<std::string> deviceFPUTypes(QLDeviceTarget device_target = QLDeviceTarget());
   std::vector<std::tuple<std::string, int>> deviceResourceInformation(QLDeviceTarget device_target = QLDeviceTarget());
   
   std::filesystem::path deviceTypeDirPath(QLDeviceTarget device_target = QLDeviceTarget());

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -69,6 +69,13 @@ bool isFpuMultGenerator(const std::string& ipName) {
   return ipName.rfind(kFpuMultPrefix, 0) == 0;
 }
 
+// Prefix of the versioned FPU add/sub generator IPs (fpu_addsub_generator_v1_0, ...).
+const char* const kFpuAddsubPrefix = "fpu_addsub_generator_v";
+
+bool isFpuAddsubGenerator(const std::string& ipName) {
+  return ipName.rfind(kFpuAddsubPrefix, 0) == 0;
+}
+
 // Single source of truth for whether a catalog IP is supported by the current
 // device, shared by the ip_catalog listing, the ip_catalog <name> query, and
 // configure_ip so all three agree.
@@ -89,6 +96,11 @@ bool isIpVersionSupported(const std::string& ipName) {
   if (isFpuMultGenerator(ipName)) {
     const auto types = QLDeviceManager::getInstance()->deviceFPUTypes();
     return types.count("FPUMULT") > 0;
+  }
+  // The add/sub member requires the "FPUADDSUB" capability token, same scheme.
+  if (isFpuAddsubGenerator(ipName)) {
+    const auto types = QLDeviceManager::getInstance()->deviceFPUTypes();
+    return types.count("FPUADDSUB") > 0;
   }
   return true;  // other IPs are not device-gated
 }

--- a/src/IPGenerate/IPGenerator.cpp
+++ b/src/IPGenerate/IPGenerator.cpp
@@ -62,6 +62,13 @@ bool isDspGenerator(const std::string& ipName) {
   return ipName.rfind(kDspPrefix, 0) == 0;
 }
 
+// Prefix of the versioned FPU multiplier generator IPs (fpu_mult_generator_v1_0, ...).
+const char* const kFpuMultPrefix = "fpu_mult_generator_v";
+
+bool isFpuMultGenerator(const std::string& ipName) {
+  return ipName.rfind(kFpuMultPrefix, 0) == 0;
+}
+
 // Single source of truth for whether a catalog IP is supported by the current
 // device, shared by the ip_catalog listing, the ip_catalog <name> query, and
 // configure_ip so all three agree.
@@ -76,7 +83,14 @@ bool isIpVersionSupported(const std::string& ipName) {
     return ipName ==
            kDspPrefix + QLDeviceManager::getInstance()->deviceDSPVersion();
   }
-  return true;  // non-DSP IPs are not device-gated
+  // FPU IPs are gated on a device capability token in the "FPU_TYPE" array of
+  // config.json (opt-in): the multiplier requires "FPUMULT". Absent/empty/
+  // non-array FPU_TYPE (or one lacking FPUMULT) hides the IP.
+  if (isFpuMultGenerator(ipName)) {
+    const auto types = QLDeviceManager::getInstance()->deviceFPUTypes();
+    return types.count("FPUMULT") > 0;
+  }
+  return true;  // other IPs are not device-gated
 }
 }  // namespace
 


### PR DESCRIPTION
Device-gates the FPU IP-Catalog generators so they appear only on devices that
declare support, mirroring the existing DSP gating but keyed on a **capability
set** rather than a version.

## Change
- `QLDeviceManager::deviceFPUTypes()` (new): parses the device `config.json`
  key **`FPU_TYPE`** — a JSON array of capability tokens (e.g.
  `["FPUMULT","FPUADDSUB"]`) — into a `std::set<std::string>`. Returns an
  **empty set** when the key is absent, empty, or not a string array, giving
  opt-in behavior. Loaded via `loadDeviceConfigJSON()`, same as
  `deviceDSPVersion()`.
- `isIpVersionSupported()` (extended) in `src/IPGenerate/IPGenerator.cpp`:
  - `fpu_mult_generator_v*`   → supported iff `FPU_TYPE` contains `FPUMULT`
  - `fpu_addsub_generator_v*` → supported iff `FPU_TYPE` contains `FPUADDSUB`
  - non-FPU IPs unchanged.
  Reuses the same three call sites as DSP (`ip_catalog` listing,
  `ip_catalog <name>`, `configure_ip`), so all three agree.

## Behavior
On a device whose `FPU_TYPE` includes the token, `ip_catalog` lists the IP and
`configure_ip` succeeds; otherwise the IP is hidden from `ip_catalog` and
`configure_ip` rejects it as unsupported. A device with no `FPU_TYPE` key
exposes no FPU IP (opt-in).

## Notes
- Difference from DSP: DSP gates by *version* (`DSPV2` → `dsp_generator_v2_0`)
  and defaults to available; the FPU family gates by *capability token*,
  independent of catalog version, and is opt-in.
- Pairs with: the ipgenerator IPs (QuickLogic-Corp/ipgenerator#17) and the
  device_data `FPU_TYPE` keys (separate PR). aurora2 submodule pins bump after
  these merge.
- Design reference: aurora2 `docs/specs/fpu-mult-generator/` (Appendix E).
